### PR TITLE
fixes #47

### DIFF
--- a/Source/Public/Connect-AZDOPS.ps1
+++ b/Source/Public/Connect-AZDOPS.ps1
@@ -17,7 +17,7 @@ function Connect-AZDOPS {
     $Credential = [pscredential]::new($Username, (ConvertTo-SecureString -String $PersonalAccessToken -AsPlainText -Force))
     $ShouldBeDefault = $Default.IsPresent
 
-    if ($AZDOPSCredentials.Count -eq 0) {
+    if ($script:AZDOPSCredentials.Count -eq 0) {
         $ShouldBeDefault = $true
         $Script:AZDOPSCredentials = @{}
     }


### PR DESCRIPTION
This fixes the bug in #47 

If you have a variable `$AZDOPSCredentials` set in your console when adding the initial connection it will fail.
I do need help to write a test to recreate this bug.
How do I set a variable in "console" scope in pester? @JohnRoos 