### PR TITLE
Help docs, parameter naming consistency, bug fixes

### DIFF
--- a/Docs/Help/Get-AZDOPSProject.md
+++ b/Docs/Help/Get-AZDOPSProject.md
@@ -5,46 +5,45 @@ online version:
 schema: 2.0.0
 ---
 
-# Remove-AZDOPSVariableGroup
+# Get-AZDOPSProject
 
 ## SYNOPSIS
 
-Removes a variable group from Azure DevOps.
+Gets one or several projects in an Azure DevOps organization.
 
 ## SYNTAX
 
 ```powershell
-Remove-AZDOPSVariableGroup [[-Organization] <String>] [-Project] <String> [-VariableGroupName] <String>
- [<CommonParameters>]
+Get-AZDOPSProject [[-Organization] <String>] [[-Project] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Removes a variable group from Azure DevOps.
+Gets one or several projects in an Azure DevOps organization.
 
 ## EXAMPLES
 
 ### Example 1
 
 ```powershell
-Remove-AZDOPSVariableGroup -Organization 'azdops' -Project 'azdopsproj' -VariableGroupName 'ExampleVarGroup'
+PS C:\> Get-AZDOPSProject -Organization 'azdops' -Project 'azdopsproj'
 ```
 
-Removes the variable group called "ExampleVarGroup" from the project "azdopsproj" in the organization "azdops".
+Gets the project called "azdopsproj" from the organization "azdops".
 
 ### Example 2
 
 ```powershell
-Remove-AZDOPSVariableGroup -Project 'azdopsproj' -VariableGroupName 'ExampleVarGroup'
+PS C:\> Get-AZDOPSProject -Project 'azdopsproj'
 ```
 
-Removes the variable group called "ExampleVarGroup" from the project "azdopsproj" in the default organization.
+Gets the project called "azdopsproj" from the default organization.
 
 ## PARAMETERS
 
 ### -Organization
 
-Name of the Azure DevOps organization.
+The name of the organization of the project.
 
 ```yaml
 Type: String
@@ -60,31 +59,15 @@ Accept wildcard characters: False
 
 ### -Project
 
-Name of the Azure DevOps project.
+The name of the project to find.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -VariableGroupName
-
-Name of the variable group to remove.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/New-AZDOPSProject.md
+++ b/Docs/Help/New-AZDOPSProject.md
@@ -1,0 +1,167 @@
+---
+external help file: AZDOPS-help.xml
+Module Name: AZDOPS
+online version:
+schema: 2.0.0
+---
+
+# New-AZDOPSProject
+
+## SYNOPSIS
+
+Creates a new project in Azure DevOps.
+
+## SYNTAX
+
+```powershell
+New-AZDOPSProject [-Name] <String> [[-Description] <String>] [-Visibility] <String>
+ [[-SourceControlType] <String>] [[-ProcessTypeName] <String>] [[-Organization] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Creates a new project in Azure DevOps.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> New-AZDOPSProject -Name 'azdopsproj' -Description 'an example project' -Visibility Public -Organization 'azdops'
+```
+
+Creates a new, public project called "azdopsproj" with a description in the organization "azdops".
+
+### Example 2
+
+```powershell
+PS C:\> New-AZDOPSProject -Name 'azdopsproj' -Visibility Private -ProcessTypeName 'Agile'
+```
+
+Creates a new, private project called "azdopsproj" with the process type "Agile" in the default organization.
+
+### Example 3
+
+```powershell
+PS C:\> New-AZDOPSProject -Name 'azdopsproj' -Visibility Private -ProcessTypeName 'MyOwnProcess' -SourceControlType 'Tfvc'
+```
+
+Creates a new, private project called "azdopsproj" with an existing, custom process type "MyOwnProcess" in the default organization, with the source control type set to Team Foundation Version Control.
+
+## PARAMETERS
+
+### -Name
+
+The name of the new project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+
+The description of the new project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Organization
+
+The organization to create the project in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Visibility
+
+The visibility of the project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Private, Public
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProcessTypeName
+
+The name of a process to use in the project.
+
+This can be the name of an existing process such as Basic, Agile, Scrum or CMMI. It can also be the name of a custom process created in the organization.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceControlType
+
+The source control type to use in the project. The default is git.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Git, Tfvc
+
+Required: False
+Position: 3
+Default value: Git
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/New-AZDOPSVariableGroup.md
+++ b/Docs/Help/New-AZDOPSVariableGroup.md
@@ -1,0 +1,209 @@
+---
+external help file: AZDOPS-help.xml
+Module Name: AZDOPS
+online version:
+schema: 2.0.0
+---
+
+# New-AZDOPSVariableGroup
+
+## SYNOPSIS
+
+Creates a new variable group in an Azure DevOps project.
+
+## SYNTAX
+
+### VariableHashtable
+
+```powershell
+New-AZDOPSVariableGroup [-Organization <String>] -Project <String> -VariableGroupName <String>
+ [-Description <String>] [-VariableHashtable <Hashtable[]>] [<CommonParameters>]
+```
+
+### VariableSingle
+
+```powershell
+New-AZDOPSVariableGroup [-Organization <String>] -Project <String> -VariableGroupName <String>
+ [-VariableName <String>] [-VariableValue <String>] [-IsSecret] [-Description <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Creates a new variable group in an Azure DevOps project.
+
+The command only supports a single variable being created together with the variable group.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> New-AZDOPSVariableGroup -Project 'azdopsproj' -Organization 'azdops' -VariableGroupName 'azdopsvars' -Description 'vargroup example' -VariableHashtable @{
+    'var-name' = @{
+        'value' = 'var-value'
+        'isSecret' = $false
+    }
+}
+```
+
+Creates a new variable group called "azdopsvars" in the project "azdopsproj" in the organization "azdops" with a description, providing a hashtable to create a non-secret variable called "var-name" with the value "var-value".
+
+### Example 2
+
+```powershell
+PS C:\> New-AZDOPSVariableGroup -Project 'azdopsproj' -VariableGroupName 'azdopsvars' -VariableName 'var-name' -VariableValue 'var-value'
+```
+
+Creates a new variable group called "azdopsvars" in the project "azdopsproj" in the default organization, creating a variable called "var-name" with the value "var-value".
+
+## PARAMETERS
+
+### -Description
+
+The description of the variable group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsSecret
+
+Whether or not the variable created should be considered a secret.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: VariableSingle
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Organization
+
+The organization of the project to create the variable group in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+
+The name of the project to create the variable group in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VariableGroupName
+
+The name of the new variable group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VariableHashtable
+
+A hashtable containing the variable to be created with the variable group.
+@{
+    'exampleName' = @{
+        'value' = 'exampleValue'
+        'isSecret' = $false
+    }
+}
+
+```yaml
+Type: Hashtable
+Parameter Sets: VariableHashtable
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VariableName
+
+The name of the variable to be created with the variable group.
+
+```yaml
+Type: String
+Parameter Sets: VariableSingle
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -VariableValue
+
+The value of the variable to be created with the variable group.
+
+```yaml
+Type: String
+Parameter Sets: VariableSingle
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Source/Public/Get-AZDOPSProject.ps1
+++ b/Source/Public/Get-AZDOPSProject.ps1
@@ -5,7 +5,7 @@ function Get-AZDOPSProject {
         [string]$Organization,
 
         [Parameter()]
-        [string]$ProjectName
+        [string]$Project
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {
@@ -21,8 +21,8 @@ function Get-AZDOPSProject {
     $Method = 'GET'
     $ProjectInfo = (InvokeAZDOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization).value
 
-    if (-not [string]::IsNullOrWhiteSpace($ProjectName)) {
-        $ProjectInfo = $ProjectInfo | Where-Object -Property Name -eq $ProjectName
+    if (-not [string]::IsNullOrWhiteSpace($Project)) {
+        $ProjectInfo = $ProjectInfo | Where-Object -Property Name -eq $Project
     }
 
     Write-Output $ProjectInfo

--- a/Source/Public/New-AZDOPSVariableGroup.ps1
+++ b/Source/Public/New-AZDOPSVariableGroup.ps1
@@ -1,39 +1,32 @@
 function New-AZDOPSVariableGroup {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory,
-            ParameterSetName = "VariableSingle")]
-
-        [Parameter(Mandatory,
-            ParameterSetName = "VariableHashtable")]
+        [Parameter(ParameterSetName = 'VariableSingle')]
+        [Parameter(ParameterSetName = 'VariableHashtable')]
         [string]$Organization,
 
-        [Parameter(Mandatory,
-            ParameterSetName = "VariableSingle")]
+        [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
         
-        [Parameter(Mandatory,
-            ParameterSetName = "VariableHashtable")]
-        [string]$ProjectName,
+        [Parameter(Mandatory, ParameterSetName = 'VariableHashtable')]
+        [string]$Project,
 
-        [Parameter(Mandatory,
-            ParameterSetName = "VariableSingle")]
-        [Parameter(Mandatory,
-            ParameterSetName = "VariableHashtable")]
+        [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
+        [Parameter(Mandatory, ParameterSetName = 'VariableHashtable')]
         [string]$VariableGroupName,
 
-        [Parameter(ParameterSetName = "VariableSingle")]
+        [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
         [string]$VariableName,
 
-        [Parameter(ParameterSetName = "VariableSingle")]
+        [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
         [string]$VariableValue,
 
-        [Parameter(ParameterSetName = "VariableSingle")]
+        [Parameter(ParameterSetName = 'VariableSingle')]
         [switch]$IsSecret,
 
         [Parameter()]
         [string]$Description,
 
-        [Parameter(ParameterSetName = "VariableHashtable")]
+        [Parameter(Mandatory, ParameterSetName = 'VariableHashtable')]
         [hashtable]$VariableHashtable
     )
 
@@ -45,41 +38,41 @@ function New-AZDOPSVariableGroup {
         $Organization = $Org['Organization']
     }
 
-    $ProjectInfo = Get-AZDOPSProject -Organization $Organization -ProjectName $ProjectName
+    $ProjectInfo = Get-AZDOPSProject -Organization $Organization -Project $Project
 
     $URI = "https://dev.azure.com/${Organization}/_apis/distributedtask/variablegroups?api-version=7.1-preview.2"
     $method = 'POST'
 
     if ($VariableName) {
         $Body = @{
-            Name                           = "$VariableGroupName"
-            Description                    = "$Description"
-            Type                           = "Vsts"
+            Name                           = $VariableGroupName
+            Description                    = $Description
+            Type                           = 'Vsts'
             variableGroupProjectReferences = @(@{
-                    Name             = "$VariableGroupName"
-                    Description      = "$Description"
+                    Name             = $VariableGroupName
+                    Description      = $Description
                     projectReference = @{
-                        Id = "$($ProjectInfo.Id)"
+                        Id = $ProjectInfo.Id
                     }
                 })
             variables                      = @{
-                "$VariableName" = @{
+                $VariableName = @{
                     isSecret = $IsSecret.IsPresent
-                    value    = "$VariableValue"
+                    value    = $VariableValue
                 }
             }
         } | ConvertTo-Json -Depth 10
     }
     else {
         $Body = @{
-            Name                           = "$VariableGroupName"
-            Description                    = "$Description"
-            Type                           = "Vsts"
+            Name                           = $VariableGroupName
+            Description                    = $Description
+            Type                           = 'Vsts'
             variableGroupProjectReferences = @(@{
-                    Name             = "$VariableGroupName"
-                    Description      = "$Description"
+                    Name             = $VariableGroupName
+                    Description      = $Description
                     projectReference = @{
-                        Id = "$($ProjectInfo.Id)"
+                        Id = $($ProjectInfo.Id)
                     }
                 })
             variables                      = $VariableHashtable

--- a/Source/Public/Remove-AZDOPSVariableGroup.ps1
+++ b/Source/Public/Remove-AZDOPSVariableGroup.ps1
@@ -5,7 +5,7 @@ function Remove-AZDOPSVariableGroup {
         [string]$Organization,
 
         [Parameter(Mandatory)]
-        [string]$ProjectName,
+        [string]$Project,
 
         [Parameter(Mandatory)]
         [string]$VariableGroupName
@@ -19,7 +19,7 @@ function Remove-AZDOPSVariableGroup {
         $Organization = $Org['Organization']
     }
 
-    $Uri = "https://dev.azure.com/$Organization/$ProjectName/_apis/distributedtask/variablegroups?api-version=7.1-preview.2"
+    $Uri = "https://dev.azure.com/$Organization/$Project/_apis/distributedtask/variablegroups?api-version=7.1-preview.2"
     $VariableGroups = (InvokeAZDOPSRestMethod -Uri $Uri -Method 'Get' -Organization $Organization).value
 
     $GroupToRemove = $VariableGroups | Where-Object name -eq $VariableGroupName
@@ -27,7 +27,7 @@ function Remove-AZDOPSVariableGroup {
         throw "Could not find group $VariableGroupName! Groups found: $($VariableGroups.name -join ', ')."
     }
     
-    $ProjectId = (Get-AZDOPSProject -Organization $Organization -ProjectName $ProjectName).id
+    $ProjectId = (Get-AZDOPSProject -Organization $Organization -Project $Project).id
 
     $URI = "https://dev.azure.com/$Organization/_apis/distributedtask/variablegroups/$($GroupToRemove.id)?projectIds=$ProjectId&api-version=7.1-preview.2"
     $null = InvokeAZDOPSRestMethod -Uri $Uri -Method 'Delete' -Organization $Organization

--- a/Tests/New-AZDOPSProject.tests.ps1
+++ b/Tests/New-AZDOPSProject.tests.ps1
@@ -68,31 +68,31 @@ InModuleScope -ModuleName AZDOPS {
                 } -ParameterFilter { $method -eq 'Post' }
 
                 $OrganizationName = 'DummyOrg'
-                $ProjectName = 'DummyOrg'
+                $Project = 'DummyOrg'
             }
 
             It 'uses InvokeAZDOPSRestMethod two times' {
-                New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -Visibility Private
+                New-AZDOPSProject -Organization $OrganizationName -Name $Project -Visibility Private
 
                 Should -Invoke 'InvokeAZDOPSRestMethod' -ModuleName 'AZDOPS' -Exactly -Times 2
             }
             It 'returns output after creating project' {
-                New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -Visibility 'Public' | Should -BeOfType [pscustomobject] -Because 'InvokeAZDOPSRestMethod should convert the json to pscustomobject'
+                New-AZDOPSProject -Organization $OrganizationName -Name $Project -Visibility 'Public' | Should -BeOfType [pscustomobject] -Because 'InvokeAZDOPSRestMethod should convert the json to pscustomobject'
             }
             It 'should not throw with mandatory parameters' {
-                { New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -Visibility 'Public' } | Should -Not -Throw
+                { New-AZDOPSProject -Organization $OrganizationName -Name $Project -Visibility 'Public' } | Should -Not -Throw
             }
             It 'should throw with invalid Visibility parameter' {
-                { New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -Visibility 'DummyVisibility' } | Should -Throw
+                { New-AZDOPSProject -Organization $OrganizationName -Name $Project -Visibility 'DummyVisibility' } | Should -Throw
             }
             It 'should throw with invalid SourceControlType parameter' {
-                { New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -SourceControlType 'DummySourceControl' -Visibility 'Private' } | Should -Throw
+                { New-AZDOPSProject -Organization $OrganizationName -Name $Project -SourceControlType 'DummySourceControl' -Visibility 'Private' } | Should -Throw
             }
             It 'should throw with invalid ProcessTypeName parameter' {
-                { New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -ProcessTypeName "Dummy Process" -Visibility 'Private' } | Should -Throw
+                { New-AZDOPSProject -Organization $OrganizationName -Name $Project -ProcessTypeName "Dummy Process" -Visibility 'Private' } | Should -Throw
             }
             It 'should not throw with Basic ProcessTypeName parameter' {
-                { New-AZDOPSProject -Organization $OrganizationName -Name $ProjectName -ProcessTypeName "Basic" -Visibility 'Private' } | Should -Not -Throw
+                { New-AZDOPSProject -Organization $OrganizationName -Name $Project -ProcessTypeName "Basic" -Visibility 'Private' } | Should -Not -Throw
             }
         }
 

--- a/Tests/Remove-AZDOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-AZDOPSVariableGroup.tests.ps1
@@ -63,20 +63,20 @@ InModuleScope -ModuleName AZDOPS {
                 }
 
                 $OrganizationName = 'DummyOrg'
-                $ProjectName = 'DummyProject'
+                $Project = 'DummyProject'
                 $VariableGroupName = 'DummyGroup'
             }
 
             It 'uses InvokeAZDOPSRestMethod two times' {
-                Remove-AZDOPSVariableGroup -ProjectName $ProjectName -VariableGroupName $VariableGroupName
+                Remove-AZDOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName
 
                 Should -Invoke 'InvokeAZDOPSRestMethod' -ModuleName 'AZDOPS' -Exactly -Times 2
             }
             It 'returns empty output after removing variable group' {
-                Remove-AZDOPSVariableGroup -ProjectName $ProjectName -VariableGroupName $VariableGroupName | Should -BeNullOrEmpty
+                Remove-AZDOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName | Should -BeNullOrEmpty
             }
             It 'should not throw with mandatory parameters' {
-                { Remove-AZDOPSVariableGroup -ProjectName $ProjectName -VariableGroupName $VariableGroupName } | Should -Not -Throw
+                { Remove-AZDOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName } | Should -Not -Throw
             }
         }
 
@@ -87,11 +87,11 @@ InModuleScope -ModuleName AZDOPS {
             It 'Organization should not be required' {
                 (Get-Command Remove-AZDOPSVariableGroup).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
             }
-            It 'Should have parameter ProjectName' {
-                (Get-Command Remove-AZDOPSVariableGroup).Parameters.Keys | Should -Contain 'ProjectName'
+            It 'Should have parameter Project' {
+                (Get-Command Remove-AZDOPSVariableGroup).Parameters.Keys | Should -Contain 'Project'
             }
-            It 'ProjectName should be required' {
-                (Get-Command Remove-AZDOPSVariableGroup).Parameters['ProjectName'].Attributes.Mandatory | Should -Be $true
+            It 'Project should be required' {
+                (Get-Command Remove-AZDOPSVariableGroup).Parameters['Project'].Attributes.Mandatory | Should -Be $true
             }
             It 'Should have parameter VariableGroupName' {
                 (Get-Command Remove-AZDOPSVariableGroup).Parameters.Keys | Should -Contain 'VariableGroupName'


### PR DESCRIPTION
# Overview/Summary

Added documentation for commands with missing help. Improved parameter naming consistency from `ProjectName` -> `Project`. Improved `New-AZDOPSVariableGroup` parameter combinations to remove possibility for user to run command without needed parameters.

## This PR fixes/adds/changes/removes

- Closes #70
- Closes #71
- Closes #72

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/bjompen/AZDOPS/pulls)
- [X] Associated it with relevant [issues](https://github.com/bjompen/AZDOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/bjompen/AZDOPS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
