### PR TITLE
add additional tests for: Connect-ADOPS, Get-ADOPSPipeline and Get-ADOPSProject

### DIFF
--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -189,3 +189,13 @@ Describe 'Bugfixes' {
         }
     }
 }
+
+Describe 'Validating try catch.' {
+    Context 'Connect-ADOPS' {
+        it 'Should trow if InvokeADOPSRestMethod returns error.' {
+            Mock -CommandName InvokeADOPSRestMethod -MockWith {return throw} -ModuleName ADOPS
+            
+            {Connect-ADOPS -Username 'DummyUser1' -PersonalAccessToken 'MyPatGoesHere' -Organization 'MyOrg'} | Should -Throw
+        }
+    }
+}

--- a/Tests/Disconnect-ADOPS.tests.ps1
+++ b/Tests/Disconnect-ADOPS.tests.ps1
@@ -67,6 +67,18 @@ Describe 'Disconnect-ADOPS tests' {
                 $Script:ADOPSCredentials.Count | Should -BeExactly 0
             }
         }
+
+        Context 'Validate throw when no Connections.' {
+            BeforeAll {
+                $Script:ADOPSCredentials = $null
+            }
+
+            It 'should throw when no Connections is availiable' {
+                $Script:ADOPSCredentials.Count | Should -BeExactly 0
+                { Disconnect-ADOPS } | Should -Throw
+                $Script:ADOPSCredentials.Count | Should -BeExactly 0
+            }
+        }
     }
 
     Context 'Verifying parameters' {

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -90,6 +90,12 @@ InModuleScope -ModuleName ADOPS {
             It 'should not throw with mandatory parameters' {
                 { Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName } | Should -Not -Throw
             }
+            It 'should not throw without Organization parameter' {
+                { Get-ADOPSPipeline -Project $Project -Name $PipeName } | Should -Not -Throw
+            }
+            It 'should throw if pipeline name does not exist' {
+                { Get-ADOPSPipeline -Project $Project -Name 'MissingPipeline' } | Should -Throw
+            }
             It 'returns single output after getting pipeline' {
                 (Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName).count | Should -Be 1
             }

--- a/Tests/Get-ADOPSProject.Tests.ps1
+++ b/Tests/Get-ADOPSProject.Tests.ps1
@@ -1,0 +1,74 @@
+Remove-Module ADOPS -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\Source\ADOPS
+
+InModuleScope -ModuleName ADOPS {
+    Describe 'Get-ADOPSProject tests' {
+        Context 'Get project' {
+            BeforeAll {
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                } -ParameterFilter { $OrganizationName -eq 'Organization' }
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                }
+
+                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                    return @'
+                    {
+                        "value": [
+                            {
+                                "id": "34f7babc-b656-4d13-bf24-bba1782d88fe",
+                                "name": "DummyProject",
+                                "description": "DummyProject",
+                                "url": "https://dev.azure.com/DummyOrg/_apis/projects/34f7babc-b656-4d13-bf24-bba1782d88fe",
+                                "state": "wellFormed",
+                                "revision": 1,
+                                "visibility": "private",
+                            }
+                        ]
+                    }
+'@ | ConvertFrom-Json
+                } -ParameterFilter { $method -eq 'GET' }
+
+                $OrganizationName = 'DummyOrg'
+                $Project = 'DummyProject'
+            }
+
+            It 'uses InvokeADOPSRestMethod one time.' {
+                Get-ADOPSProject -Organization $OrganizationName -Project $Project 
+                Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+            }
+            It 'returns output after getting project' {
+                Get-ADOPSProject -Organization $OrganizationName -Project $Project | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
+            }
+            It 'should not throw with no parameters' {
+                { Get-ADOPSProject } | Should -Not -Throw
+            }
+        }
+
+        Context 'Parameters' {
+            It 'Should have parameter Organization' {
+                (Get-Command Get-ADOPSProject).Parameters.Keys | Should -Contain 'Organization'
+            }
+            It 'Organization should not be required' {
+                (Get-Command Get-ADOPSProject).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
+            }
+            It 'Should have parameter Project' {
+                (Get-Command Get-ADOPSProject).Parameters.Keys | Should -Contain 'Project'
+            }
+            It 'Project not should be required' {
+                (Get-Command Get-ADOPSProject).Parameters['Project'].Attributes.Mandatory | Should -Be $false
+            }
+        }
+    }
+}

--- a/Tests/New-ADOPSProject.tests.ps1
+++ b/Tests/New-ADOPSProject.tests.ps1
@@ -80,7 +80,7 @@ InModuleScope -ModuleName ADOPS {
                 New-ADOPSProject -Organization $OrganizationName -Name $Project -Visibility 'Public' | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
             }
             It 'should not throw with mandatory parameters' {
-                { New-ADOPSProject -Organization $OrganizationName -Name $Project -Visibility 'Public' } | Should -Not -Throw
+                { New-ADOPSProject -Name $Project -Visibility 'Public' } | Should -Not -Throw
             }
             It 'should throw with invalid Visibility parameter' {
                 { New-ADOPSProject -Organization $OrganizationName -Name $Project -Visibility 'DummyVisibility' } | Should -Throw
@@ -94,6 +94,10 @@ InModuleScope -ModuleName ADOPS {
             It 'should not throw with Basic ProcessTypeName parameter' {
                 { New-ADOPSProject -Organization $OrganizationName -Name $Project -ProcessTypeName "Basic" -Visibility 'Private' } | Should -Not -Throw
             }
+            It 'returns Description output if Description is set.' {
+                (New-ADOPSProject -Organization $OrganizationName -Name $Project -Visibility 'Public' -Description 'DummyDescription').Body | ConvertFrom-Json | Select-Object -ExpandProperty Description | Should -Be 'DummyDescription'
+            }
+
         }
 
         Context 'Parameters' {

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -78,6 +78,9 @@ InModuleScope -ModuleName ADOPS {
             It 'should not throw with mandatory parameters' {
                 { Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName } | Should -Not -Throw
             }
+            It 'should throw if VariableGroupName Name is invalid' {
+                { Remove-ADOPSVariableGroup -Organization $OrganizationName -Project $Project -VariableGroupName 'MissingVariableGroupName'} | Should -Throw
+            }
         }
 
         Context 'Parameters' {


### PR DESCRIPTION
## Overview/Summary

Adding some additional tests to the functions 
Connect-ADOPS
Get-ADOPSPipeline
Get-ADOPSProject
New-ADOPSProject
Remove-ADOPSVariableGroup
Disconnect-ADOPS
for good Code Coverage.

Resolves  #83

## This PR fixes/adds/changes/removes

1. Connect-ADOPS
2. Get-ADOPSPipeline
3. Get-ADOPSProject
4. New-ADOPSProject
5. Remove-ADOPSVariableGroup
6. Disconnect-ADOPS

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
