### PR TITLE
add general cmdlet tests

### DIFF
--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -54,6 +54,22 @@ Describe "Module $ModuleName" {
             param ( $Count )
             $Count | Should -BeGreaterThan 0 -Because 'functions should exist'
         }
+        It "Public function '<Function>' should have parameter Organization." -TestCases $PublicTestCases {
+            param ( $Function )
+            (Get-Command $Function).Parameters.Keys | Should -Contain 'Organization'
+        }
+        It "Public function '<Function>' should have a CmdLet file in correct place." -TestCases $PublicTestCases {
+            param ( $Function )
+            Test-Path -Path "$ScriptDirectory\..\Source\Public\$Function.ps1" -PathType Leaf | Should -Be $true
+        }
+        It "Public function '<Function>' should have a test file." -TestCases $PublicTestCases {
+            param ( $Function )
+            Test-Path -Path "$ScriptDirectory\$Function.Tests.ps1" -PathType Leaf | Should -Be $true
+        }
+        It "Public function '<Function>' should have a Docs/Help file." -TestCases $PublicTestCases {
+            param ( $Function )
+            Test-Path -Path "$ScriptDirectory\..\Docs\Help\$Function.md" -PathType Leaf | Should -Be $true
+        }
 
         # This test only works on compiled psd1 files, and can tbe run in current build script. needs to be revisited.
         # It "Public function '<Function>' has been exported" -TestCases $PublicTestCases {
@@ -68,6 +84,14 @@ Describe "Module $ModuleName" {
             It "Private function '<Function>' has not been exported" -TestCases $PrivateTestCases {
                 param ( $Function,  $ExportedFunctions)
                 $ExportedFunctions | Should -Not -Contain $Function -Because 'the file is not in the Public folder'
+            }
+            It "Private function '<Function>' should have a CmdLet file in correct place." -TestCases $PrivateTestCases {
+                param ( $Function )
+                Test-Path -Path "$ScriptDirectory\..\Source\Private\$Function.ps1" -PathType Leaf | Should -Be $true
+            }
+            It "Private function '<Function>' should have a test file." -TestCases $PrivateTestCases {
+                param ( $Function )
+                Test-Path -Path "$ScriptDirectory\$Function.Tests.ps1" -PathType Leaf | Should -Be $true
             }
         }
     }


### PR DESCRIPTION
## Overview/Summary

Add tests.
Organization: Should always be required

All functions should have the files
.\Source<private / public>\FunctionName.ps1
.\Tests\FunctionName.Tests.ps1

If it is a public function it should also have
.\Docs\Help\FunctionName.md

Add Tests to validate Parameters in Docs/Help Files.

Connected to issue #79 

## This PR fixes/adds/changes/removes

1. Module.tests.ps1

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
