### PR TITLE
add Org param to Get-ADOPSConnection

### DIFF
--- a/Docs/Help/Get-ADOPSConnection.md
+++ b/Docs/Help/Get-ADOPSConnection.md
@@ -13,7 +13,7 @@ Gets all established connections to Azure DevOps.
 ## SYNTAX
 
 ```
-Get-ADOPSConnection
+Get-ADOPSConnection [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,7 +30,34 @@ Name                           Value
 MyOrganization                 {Credential, Default}
 ```
 
+### Example 2
+```powershell
+PS C:\> Get-ADOPSConnection -Organization "MyOrganization"
+
+Name                           Value
+----                           -----
+MyOrganization                 {Credential, Default}
+```
+
 ## PARAMETERS
+
+### -Organization
+Lists a specific Organization connection.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/Source/Public/Get-ADOPSConnection.ps1
+++ b/Source/Public/Get-ADOPSConnection.ps1
@@ -1,5 +1,15 @@
 function Get-ADOPSConnection {
-    param ()
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Organization
+    )
     
-    $Script:ADOPSCredentials
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $Script:ADOPSCredentials.GetEnumerator() | Where-Object { $_.Key -eq $Organization}
+    }
+    else {
+        $Script:ADOPSCredentials
+    }
 }

--- a/Tests/Get-ADOPSConnection.Tests.ps1
+++ b/Tests/Get-ADOPSConnection.Tests.ps1
@@ -28,7 +28,9 @@ Describe 'Get-ADOPSConnection' {
         It 'Given we have two connections, both connections should be returned' {
             (Get-ADOPSConnection).Count | Should -Be 2
         }
-
+        It 'Should return one connection if Organization parameter is used.' {
+            (Get-ADOPSConnection -Organization 'org1').Count | Should -Be 1
+        }
         It 'Verifying the first returned organization matches the set variable' {
             (Get-ADOPSConnection)['org1'].Credential.Username | Should -Be 'DummyUser1'
         }


### PR DESCRIPTION
## Overview/Summary

Add Organization parameter to Get-ADOPSConnection
Issue #93 

## This PR fixes/adds/changes/removes

1. Get-ADOPSConnection.ps1
2. Get-ADOPSConnection.Tests.ps1

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
