### PR TITLE
add Plaster Template for CmdLets

### DIFF
--- a/Tools/PSCmdLetTemplate/README.md
+++ b/Tools/PSCmdLetTemplate/README.md
@@ -1,0 +1,33 @@
+# How to use Plaster PS CmdLet Template
+
+This will create a {CmdletName}.ps1 file some basic function code, in the "Public" or "Private" folder depending on your selection.
+
+It will also create a {CmdletName}.tests.ps1 with some basic tests in the "Tests" folder.
+
+## Prerequisite
+
+In order to use the Plaster template you need to install Plaster module.
+
+```powershell
+Install-Module -Name Plaster
+```
+
+## EXAMPLES
+
+Note: you need to point 'DestinationPath' to the Root folder on the Repository.
+### EXAMPLE 1
+
+```powershell
+Invoke-Plaster -NoLogo -TemplatePath .\Tools\PSCmdLetTemplate -DestinationPath .
+```
+
+This will invoke Plaster and prompt you for 'CmdletName' and 'Type'.
+
+
+### EXAMPLE 2
+
+```powershell
+Invoke-Plaster -NoLogo -TemplatePath .\Tools\PSCmdLetTemplate -DestinationPath . -CmdletName Get-FooBar -Type Private
+``` 
+
+This will invoke Plaster using the parameters 'CmdletName' and 'Type'.

--- a/Tools/PSCmdLetTemplate/plasterManifest.xml
+++ b/Tools/PSCmdLetTemplate/plasterManifest.xml
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<plasterManifest schemaVersion="1.1"
+            templateType="Project"
+            xmlns="http://www.microsoft.com/schemas/PowerShell/Plaster/v1">
+      <metadata>
+            <name>PowerShellCmdletTemplate</name>
+            <id>8c7207cb-3d93-4131-908c-665307eec714</id>
+            <version>1.0.0</version>
+            <title>PowerShell Cmdlet</title>
+            <description>Creates a PowerShell script Cmdlet.</description>
+            <author>PwrOps</author>
+            <tags>Cmdlet, Tests</tags>
+      </metadata>
+      <parameters>
+
+            <parameter name='CmdletName'
+                        type='text'
+                        prompt='Enter the name of the Cmdlet'/>
+            
+            <parameter  name='Type'
+                        type='choice'
+                        prompt='Public or Private Cmdlet'
+                        store='text' >
+                  <choice label='&amp;Public'
+                        help="Public Cmdlet folder."
+                        value="Public"/>
+                  <choice label='P&amp;rivate'
+                        help="Private Cmdlet folder."
+                        value="Private"/>
+            </parameter>   
+
+      </parameters>
+
+      <content>
+            <message>&#10;&#10;Scaffolding your PowerShell Cmdlet...&#10;&#10;&#10;</message>
+
+            <templateFile condition="$PLASTER_PARAM_Type -eq 'Public'"
+                  source='templates\Cmdlet.ps1'
+                  destination='Source\Public\${PLASTER_PARAM_CmdletName}.ps1' />
+
+            <templateFile condition="$PLASTER_PARAM_Type -eq 'Private'"
+                  source='templates\Cmdlet.ps1'
+                  destination='Source\Private\${PLASTER_PARAM_CmdletName}.ps1' />
+
+            <templateFile source='templates\CmdletTests.ps1'
+                  destination='Tests\${PLASTER_PARAM_CmdletName}.Tests.ps1' />
+            
+            <modify path='Tests\${PLASTER_PARAM_CmdletName}.Tests.ps1'
+                  condition="$PLASTER_PARAM_Type -eq 'Private'" >
+                  <replace>
+                        <original>(?s)    Mock -CommandName InvokeADOPSRestMethod.*-Exactly -Times 1.            }</original>
+                        <substitute expand='true'>}</substitute>
+                  </replace>
+            </modify>
+
+            <modify path='Source\Private\${PLASTER_PARAM_CmdletName}.ps1'
+                  condition="$PLASTER_PARAM_Type -eq 'Private'" >
+                  <replace>
+                        <original>(?s)    \$Uri.*InvokeADOPSRestMethod @InvokeSplat</original>
+                        <substitute expand='true'></substitute>
+                  </replace>
+            </modify>
+            
+            <message>
+
+Your new PowerShell Cmdlet: '$PLASTER_PARAM_CmdletName' has been created.
+
+A Pester test has been created to validate Cmdlet '$PLASTER_PARAM_CmdletName' Code. 
+Add additional tests to the script Validate the Cmdlet.
+
+            </message>
+
+      </content>
+</plasterManifest>

--- a/Tools/PSCmdLetTemplate/templates/Cmdlet.ps1
+++ b/Tools/PSCmdLetTemplate/templates/Cmdlet.ps1
@@ -1,0 +1,26 @@
+function <%=$PLASTER_PARAM_CmdletName%> {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Organization
+    )
+    
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $OrgInfo = GetADOPSHeader -Organization $Organization
+    }
+    else {
+        $OrgInfo = GetADOPSHeader
+        $Organization = $OrgInfo['Organization']
+    }
+    
+    $Uri = ""
+    
+    $InvokeSplat = @{
+        Method       = ''
+        Uri          = $URI
+        Organization = $Organization
+    }
+
+    InvokeADOPSRestMethod @InvokeSplat
+}

--- a/Tools/PSCmdLetTemplate/templates/CmdletTests.ps1
+++ b/Tools/PSCmdLetTemplate/templates/CmdletTests.ps1
@@ -1,0 +1,53 @@
+﻿Remove-Module ADOPS -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\Source\ADOPS
+
+InModuleScope -ModuleName ADOPS {
+    Describe '<%=$PLASTER_PARAM_CmdletName%> tests' {
+        Context 'Command tests' {
+            BeforeAll {
+
+                $OrganizationName = 'DummyOrg'
+                
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                } -ParameterFilter { $OrganizationName -eq $OrganizationName }
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                }
+
+                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                    return $InvokeSplat
+                }
+
+            }
+            It 'uses InvokeADOPSRestMethod one time.' {
+                <%=$PLASTER_PARAM_CmdletName%> -Organization $OrganizationName | Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+            }
+            It 'returns output after getting pipeline' {
+                <%=$PLASTER_PARAM_CmdletName%> -Organization $OrganizationName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
+            }
+            It 'should not throw without optional parameters' {
+                { <%=$PLASTER_PARAM_CmdletName%> } | Should -Not -Throw
+            }
+        }
+
+        Context 'Parameters' {
+            It 'Should have parameter Organization' {
+                (Get-Command <%=$PLASTER_PARAM_CmdletName%>).Parameters.Keys | Should -Contain 'Organization'
+            }
+            It 'Organization should not be required' {
+                (Get-Command <%=$PLASTER_PARAM_CmdletName%>).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview/Summary

Possible solution for using a Plaster template for scaffolding your Cmdlets. 
Adds a Cmdlet file to Private/Public source folder depending on your parameter and adds corresponding test file in Tests folder.

Connected to Issue #15 

Feedback Needed.

## This PR fixes/adds/changes/removes

1. Cmdlet.ps1
2. CmdletTests.ps1
3. plasterMainfest.xml
4. README.md

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
