### PR TITLE
Buggfix ElasticPool commands

### DIFF
--- a/Docs/Help/New-ADOPSElasticPoolObject.md
+++ b/Docs/Help/New-ADOPSElasticPoolObject.md
@@ -61,6 +61,11 @@ Accept wildcard characters: False
 
 ### -AzureId
 The resource id for the Virtual Machine Scale Set in Azure.
+Retrieved using the Az.Compute module.
+```PowerShell
+Connect-AzAccount
+(Get-AzVmss -VMScaleSetName MyVMSS).Id
+```
 
 ```yaml
 Type: String
@@ -166,7 +171,7 @@ Accept wildcard characters: False
 ```
 
 ### -ServiceEndpointId
-Id of the Service Endpoint used to connect to Azure
+Id of the Service Endpoint used to connect to Azure.
 
 ```yaml
 Type: Guid
@@ -181,7 +186,8 @@ Accept wildcard characters: False
 ```
 
 ### -ServiceEndpointScope
-Scope the Service Endpoint belongs to
+Scope the Service Endpoint belongs to.
+To find your serviceEndpointScope, use Get-ADOPSProject as the scope is the project where the Service connection is bound.
 
 ```yaml
 Type: Guid

--- a/Source/Public/Get-ADOPSElasticPool.ps1
+++ b/Source/Public/Get-ADOPSElasticPool.ps1
@@ -17,13 +17,18 @@ function Get-ADOPSElasticPool {
     }
 
     if ($PSBoundParameters.ContainsKey('PoolId')) {
-        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools/$PoolId?api-version=7.1-preview.1"
+        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools/${PoolId}?api-version=7.1-preview.1"
     } else {
         $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?api-version=7.1-preview.1"
     }
     
-    $Method = 'GET'
-    $ElasticPoolInfo = InvokeADOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization -Body $Body
+    $InvokeSplat = @{
+        Uri = $Uri
+        Method = 'Get'
+        Organization = $Organization
+    }
+    $ElasticPoolInfo = InvokeADOPSRestMethod @InvokeSplat
+    
     if ($ElasticPoolInfo.psobject.properties.name -contains 'value') {
         Write-Output $ElasticPoolInfo.value
     } else {

--- a/Source/Public/New-ADOPSElasticpool.ps1
+++ b/Source/Public/New-ADOPSElasticpool.ps1
@@ -36,7 +36,19 @@ function New-ADOPSElasticPool {
         $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?poolName=$PoolName`&authorizeAllPipelines=$AuthorizeAllPipelines`&autoProvisionProjectPools=$AutoProvisionProjectPools&api-version=7.1-preview.1"
     }
     
-    $Method = 'POST'
-    $ElasticPoolInfo = InvokeADOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization -Body $Body
+    try {
+        $null = $ElasticPoolObject | ConvertFrom-Json
+    }
+    catch {
+        $ElasticPoolObject = $ElasticPoolObject | ConvertTo-Json -Compress -Depth 10
+    }
+
+    $InvokeSplat = @{
+        Method = 'post'
+        Uri = $Uri
+        Organization = $Organization
+        Body = $ElasticPoolObject
+    }
+    $ElasticPoolInfo = InvokeADOPSRestMethod @InvokeSplat
     Write-Output $ElasticPoolInfo
 }

--- a/Tests/New-ADOPSElasticpool.Tests.ps1
+++ b/Tests/New-ADOPSElasticpool.Tests.ps1
@@ -3,12 +3,64 @@ Import-Module $PSScriptRoot\..\Source\ADOPS -Force
 
 Describe "New-ADOPSElasticpool" {
     Context "Function tests" {
+        BeforeAll {
+            InModuleScope -ModuleName ADOPS {
+                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                    return $InvokeSplat
+                }
+
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                }
+            }
+
+        }
+
         It "Function exists" {
             { Get-Command -Name New-ADOPSElasticpool -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Has parameter <_>' -TestCases 'Organization', 'ElasticPoolObject', 'ProjectId', 'PoolName', 'AuthorizeAllPipelines', 'AutoProvisionProjectPools' {
             (Get-Command -Name New-ADOPSElasticpool).Parameters.Keys | Should -Contain $_
+        }
+        It 'PoolName should be required' {
+            (Get-Command New-ADOPSElasticpool).Parameters['PoolName'].Attributes.Mandatory | Should -Be $true
+        }
+        It 'ElasticPoolObject should be required' {
+            (Get-Command New-ADOPSElasticpool).Parameters['ElasticPoolObject'].Attributes.Mandatory | Should -Be $true
+        }
+
+        It 'Should have called mock' {
+            $r = New-ADOPSElasticPool -PoolName 'DummyPoolName' -ElasticPoolObject 'EPO' -Organization 'DummyOrg' -ProjectId 'ProjectId' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+            Should -Invoke 'GetADOPSHeader' -ModuleName 'ADOPS' -Exactly -Times 1
+        }
+
+        It 'Verifying invoke object, URI' {
+            $r = New-ADOPSElasticPool -PoolName 'DummyPoolName' -ElasticPoolObject 'EPO' -Organization 'DummyOrg' -ProjectId 'ProjectId' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true
+            $r.uri | Should -Be "https://dev.azure.com/DummyOrg/_apis/distributedtask/elasticpools?poolName=DummyPoolName&authorizeAllPipelines=true&autoProvisionProjectPools=true&projectId=ProjectId&api-version=7.1-preview.1"
+        }
+        It 'Verifying invoke object, method' {
+            $r = New-ADOPSElasticPool -PoolName 'DummyPoolName' -ElasticPoolObject 'EPO' -Organization 'DummyOrg' -ProjectId 'ProjectId' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true
+            $r.method | Should -Be 'Post'
+        }
+        It 'Verifying invoke object, Organization' {
+            $r = New-ADOPSElasticPool -PoolName 'DummyPoolName' -ElasticPoolObject 'EPO' -Organization 'DummyOrg' -ProjectId 'ProjectId' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true
+            $r.Organization | Should -Be 'DummyOrg'
+        }
+        It 'Verifying invoke object, Body' {
+            $r = New-ADOPSElasticPool -PoolName 'DummyPoolName' -ElasticPoolObject '{"EpoKey":"EPO"}' -Organization 'DummyOrg' -ProjectId 'ProjectId' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true
+            $r.Body | Should -Be '{"EpoKey":"EPO"}'
+        }
+
+        It 'If elasticPoolObject is not a Json, try to convert it' {
+            $r = New-ADOPSElasticPool -PoolName 'DummyPoolName' -ElasticPoolObject (@{'EpoKey'='EPO'}) -Organization 'DummyOrg' -ProjectId 'ProjectId' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true
+            $r.Body | Should -Be '{"EpoKey":"EPO"}'
         }
     }
 


### PR DESCRIPTION
Contains added tests and fixes for the elastic pools commands.

## New-ADOPSElasticPool

[x] Change -Body in Invoke to use correct parameter, $ElasticPoolObject

[x] Check if $ElasticPoolObject is json, if not, try to convert it

[x] Add help on how to find VMSS id for parameter 'azureID' (Get-AZVMSS from the Az.Compute module)

## Get-ADOPSElasticPool

[x] Fix variable expansion error when searching for specific id.

[x] Remove unnecessary $Body from invoke call

## General

[x] Update Help

[x] Run tests
