### PR TITLE
Create class and Default test exclusion rule

### DIFF
--- a/ADOPS.Build.ps1
+++ b/ADOPS.Build.ps1
@@ -42,7 +42,7 @@ task Compile_Module {
 
     $ExportedFunctionList = [System.Collections.Generic.List[string]]::new()
 
-    # Private functions
+    # Classes
     Get-ChildItem "$ModuleSourcePath\Classes" *.ps1 | ForEach-Object {
         $FileContent = Get-Content $_.FullName
         "#region $($_.BaseName)`n"      | Out-File $PSM1Path -Append

--- a/ADOPS.Build.ps1
+++ b/ADOPS.Build.ps1
@@ -43,6 +43,14 @@ task Compile_Module {
     $ExportedFunctionList = [System.Collections.Generic.List[string]]::new()
 
     # Private functions
+    Get-ChildItem "$ModuleSourcePath\Classes" *.ps1 | ForEach-Object {
+        $FileContent = Get-Content $_.FullName
+        "#region $($_.BaseName)`n"      | Out-File $PSM1Path -Append
+        $FileContent                    | Out-File $PSM1Path -Append
+        "#endregion $($_.BaseName)`n"   | Out-File $PSM1Path -Append
+    }
+
+    # Private functions
     Get-ChildItem "$ModuleSourcePath\Private" *.ps1 | ForEach-Object {
         $FileContent = Get-Content $_.FullName
         "#region $($_.BaseName)`n"      | Out-File $PSM1Path -Append

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ The repo is organized as below:
 
 - **Private** (`Source/Private`): All private functions used by the module.
 - **Public** (`Source/Public`): All functions exported by the module.
+- **Classes** (`Source/Classes`): All classes by the module.
 - **Tests** (`Tests`): Pester tests executed at Pull Request.
 - **Help** (`Docs\Help`): Markdown help files for external help.
 
@@ -32,6 +33,14 @@ Import-Module .\Source\ADOPS.psd1
 The ADOPS module is developed using Test-driven development(TDD) where we aim for full test coverage for all our functions. Make sure that all new features and updates are covered by Pester tests. All tests will be executed when a Pull Request is submitted as a build validation step. PRs with failing tests will not be approved.
 
 [Pester](https://github.com/pester/Pester) is the ubiquitous test and mock framework for PowerShell.
+
+Exclusion of standard tests can be done using the SkipTest attribute (See f.eg New-ADOPSElasticPoolObject)
+
+```PowerShell
+[SkipTest('HasOrganizationParameter')]
+```
+
+Introducing additional exclusions should be discussed in a GitHub issue before implemention.
 
 ### platyPS
 

--- a/Source/ADOPS.psm1
+++ b/Source/ADOPS.psm1
@@ -1,3 +1,15 @@
+# import classes
+foreach ($file in (Get-ChildItem "$PSScriptRoot\Classes\*.ps1"))
+{
+	try {
+		Write-Verbose "Importing $($file.FullName)"
+		. $file.FullName
+	}
+	catch {
+		Write-Error "Failed to import '$($file.FullName)'. $_"
+	}
+}
+
 # import private functions
 foreach ($file in (Get-ChildItem "$PSScriptRoot\Private\*.ps1"))
 {

--- a/Source/Classes/SkipTest.ps1
+++ b/Source/Classes/SkipTest.ps1
@@ -1,0 +1,8 @@
+Class SkipTest : Attribute {
+    [string]$TestName
+
+    SkipTest([string[]]$Name)
+    {
+        $this.TestName = $Name
+    }
+}

--- a/Source/Classes/SkipTest.ps1
+++ b/Source/Classes/SkipTest.ps1
@@ -1,8 +1,8 @@
-Class SkipTest : Attribute {
-    [string]$TestName
+class SkipTest : Attribute {
+    [string[]]$TestNames
 
     SkipTest([string[]]$Name)
     {
-        $this.TestName = $Name
+        $this.TestNames = $Name
     }
 }

--- a/Source/Public/New-ADOPSElasticPoolObject.ps1
+++ b/Source/Public/New-ADOPSElasticPoolObject.ps1
@@ -1,4 +1,5 @@
 function New-ADOPSElasticPoolObject {
+    [SkipTest('HasOrganizationParameter')]
     [CmdletBinding()]
     param (
         # Service Endpoint Id

--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -62,7 +62,9 @@ Describe "Module $ModuleName" {
             param ( $Count )
             $Count | Should -BeGreaterThan 0 -Because 'functions should exist'
         }
-        It "Public function '<Function>' should have parameter Organization." -TestCases $PublicTestCases {
+
+        # This test will only run on functions that does not have the [SkipTest('HasOrganizationParameter')] attribute set.
+        It "Public function '<Function>' should have parameter Organization." -TestCases $PublicTestCases.Where({-Not (Get-Command $_.Function).ScriptBlock.Attributes.Where({$_.TypeID.Name -eq 'SkipTest'}).TestName -contains 'HasOrganizationParameter'}) {
             param ( $Function )
             (Get-Command $Function).Parameters.Keys | Should -Contain 'Organization'
         }

--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -64,7 +64,7 @@ Describe "Module $ModuleName" {
         }
 
         # This test will only run on functions that does not have the [SkipTest('HasOrganizationParameter')] attribute set.
-        It "Public function '<Function>' should have parameter Organization." -TestCases $PublicTestCases.Where({-Not (Get-Command $_.Function).ScriptBlock.Attributes.Where({$_.TypeID.Name -eq 'SkipTest'}).TestName -contains 'HasOrganizationParameter'}) {
+        It "Public function '<Function>' should have parameter Organization." -TestCases $PublicTestCases.Where({-Not (Get-Command $_.Function).ScriptBlock.Attributes.Where({$_.TypeID.Name -eq 'SkipTest'}).TestNames -contains 'HasOrganizationParameter'}) {
             param ( $Function )
             (Get-Command $Function).Parameters.Keys | Should -Contain 'Organization'
         }


### PR DESCRIPTION
This PR closes #98 
Added class extension to dynamically be able to exclude tests on defaults.
Currently only adds one test exclusion, but it should be easy to add more if needed.