### PR TITLE
Add function Get-ADOPSServiceConnection Tests and Docs.

### DIFF
--- a/Docs/Help/Get-ADOPSServiceConnection.md
+++ b/Docs/Help/Get-ADOPSServiceConnection.md
@@ -1,0 +1,108 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Get-ADOPSServiceConnection
+
+## SYNOPSIS
+Get a specific ServiceConnection or all ServiceConnections in a DevOps project.
+
+## SYNTAX
+
+```
+Get-ADOPSServiceConnection [[-Name] <String>] [-Project] <String> [[-Organization] <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Lists a specific ServiceConnection or all ServiceConnections in a Project.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $Name
+
+```
+
+Get ServiceConnection with name $Name from $Project.
+
+### Example 2
+```powershell
+PS C:\> Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project
+
+```
+
+List all ServiceConnection in $Project
+
+### Example 3
+```powershell
+PS C:\> Get-ADOPSServiceConnection -Project $Project
+
+```
+
+List all ServiceConnection in $Project and uses Default Organization.
+
+## PARAMETERS
+
+### -Name
+Name of the ServiceConnection.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Organization
+The organization to get ServiceConnection/s from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+The project to get ServiceConnection/s from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Public/Get-ADOPSServiceConnection.ps1
+++ b/Source/Public/Get-ADOPSServiceConnection.ps1
@@ -1,0 +1,46 @@
+function Get-ADOPSServiceConnection {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Project,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Organization
+    )
+    
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $OrgInfo = GetADOPSHeader -Organization $Organization
+    }
+    else {
+        $OrgInfo = GetADOPSHeader
+        $Organization = $OrgInfo['Organization']
+    }
+
+    $Uri = "https://dev.azure.com/$Organization/$Project/_apis/serviceendpoint/endpoints?api-version=7.1-preview.4"
+    
+    $InvokeSplat = @{
+        Method       = 'Get'
+        Uri          = $URI
+        Organization = $Organization
+    }
+
+    $AllPipelines = (InvokeADOPSRestMethod @InvokeSplat).value
+
+    if ($PSBoundParameters.ContainsKey('Name')) {
+        $Pipelines = $AllPipelines | Where-Object {$_.name -eq $Name}
+        if (-not $Pipelines) {
+            throw "The specified ServiceConnectionName $Name was not found amongst Connections: $($AllPipelines.name -join ', ')!" 
+        } 
+    } else {
+        $Pipelines = $AllPipelines
+    }
+
+    return $Pipelines
+
+}

--- a/Tests/Get-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Get-ADOPSServiceConnection.Tests.ps1
@@ -1,0 +1,108 @@
+Remove-Module ADOPS -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\Source\ADOPS
+
+InModuleScope -ModuleName ADOPS {
+    Describe 'Get-ADOPSServiceConnection tests' {
+        Context 'Command tests' {
+            BeforeAll {
+
+                $OrganizationName = 'DummyOrg'
+                $Project = 'DummyProject'
+                $SCName = 'DummySC1'
+
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                } -ParameterFilter { $OrganizationName -eq $OrganizationName }
+                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                    @{
+                        Header       = @{
+                            'Authorization' = 'Basic Base64=='
+                        }
+                        Organization = $OrganizationName
+                    }
+                }
+
+                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                    return @'
+                    {
+                        "value": [
+                            {
+                                "data": {},
+                                "id": "e7a02fa1-ead0-43ea-aeac-d9cbbf844f90",
+                                "name": "DummySC1",
+                                "type": "azurerm",
+                                "url": "https://management.azure.com/",
+                                "createdBy": {},
+                                "description": "",
+                                "authorization": {},
+                                "isShared": false,
+                                "isReady": true,
+                                "operationStatus": {},
+                                "owner": "Library",
+                                "serviceEndpointProjectReferences": []
+                            },
+                            {
+                                "data": {},
+                                "id": "e7a02fa1-ead0-43ea-aeac-d9cbbf844f91",
+                                "name": "DummySC2",
+                                "type": "azurerm",
+                                "url": "https://management.azure.com/",
+                                "createdBy": {},
+                                "description": "",
+                                "authorization": {},
+                                "isShared": false,
+                                "isReady": true,
+                                "operationStatus": {},
+                                "owner": "Library",
+                                "serviceEndpointProjectReferences": []
+                            }
+                        ]
+                    }
+'@ | ConvertFrom-Json
+                } -ParameterFilter { $Method -eq 'Get' }
+
+            }
+            It 'uses InvokeADOPSRestMethod one time.' {
+                Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName  
+                Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+            }
+            It 'returns output after getting pipeline' {
+                Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
+            }
+            It 'should not throw without optional parameters' {
+                { Get-ADOPSServiceConnection -Project $Project } | Should -Not -Throw
+            }
+            It 'should throw if connection name does not exist' {
+                { Get-ADOPSServiceConnection -Project $Project -Name 'MissingName' } | Should -Throw
+            }
+            It 'returns single output after getting pipeline' {
+                (Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName).count | Should -Be 1
+            }
+            It 'returns multiple outputs after getting pipelines' {
+                (Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project).count | Should -Be 2
+            }
+        }
+
+        Context 'Parameters' {
+            It 'Should have parameter Organization' {
+                (Get-Command Get-ADOPSServiceConnection).Parameters.Keys | Should -Contain 'Organization'
+            }
+            It 'Organization should not be required' {
+                (Get-Command Get-ADOPSServiceConnection).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
+            }
+            It 'Should have parameter Project' {
+                (Get-Command Get-ADOPSServiceConnection).Parameters.Keys | Should -Contain 'Project'
+            }
+            It 'Should have parameter Name' {
+                (Get-Command Get-ADOPSServiceConnection).Parameters.Keys | Should -Contain 'Name'
+            }
+
+        }
+    }
+}
+


### PR DESCRIPTION
## Overview/Summary

Adds Function Get-ADOPSServiceConnection to get one or all ServiceConnections in a project.
Connected to Issue #102

## This PR fixes/adds/changes/removes

1. Add function Get-ADOPSServiceConnection.ps1
2. Add tests Get-ADOPSServiceConnection.tests.ps1
3. Add docs Get-ADOPSServiceConnection.md

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
