### PR TITLE
Get-ADOPSUser

### DIFF
--- a/Docs/Help/Get-ADOPSUser.md
+++ b/Docs/Help/Get-ADOPSUser.md
@@ -1,0 +1,118 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Get-ADOPSUser
+
+## SYNOPSIS
+
+Fetch user(s) by name or descriptor
+
+## SYNTAX
+
+### Name (Default)
+
+```
+Get-ADOPSUser [-Name] <String> [-Organization <String>] [<CommonParameters>]
+```
+
+### Descriptor
+
+```
+Get-ADOPSUser [-Descriptor] <String> [-Organization <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Fetch user(s) by name or descriptor
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Get-ADOPSUser -Name 'john doe'
+```
+
+Search for anyone that has `john doe` in it's name, display name or email.
+
+### Example 2
+
+```powershell
+PS C:\> Get-ADOPSUser -Descriptor 'aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U'
+```
+
+Search for a single user that has the corresponding descriptor.
+
+## PARAMETERS
+
+### -Descriptor
+
+A unique _descriptor_ ID for the user.
+
+```yaml
+Type: String
+Parameter Sets: Descriptor
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+
+The query that will match name, display name, email fields.
+
+```yaml
+Type: String
+Parameter Sets: Name
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Organization
+
+The organization to get users from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS
+
+https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/search-user-entitlements?view=azure-devops-rest-6.0
+
+https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/get?view=azure-devops-rest-6.0&viewFallbackFrom=azure-devops-rest-7.0

--- a/Docs/Help/Get-ADOPSUser.md
+++ b/Docs/Help/Get-ADOPSUser.md
@@ -127,8 +127,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/search-user-entitlements?view=azure-devops-rest-6.0
-
-https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/get?view=azure-devops-rest-6.0
-
-https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/list?view=azure-devops-rest-6.0
+[user-entitlements/search-user-entitlements](https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/search-user-entitlements?view=azure-devops-rest-6.0)
+[users/get](https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/get?view=azure-devops-rest-6.0)
+[users/list](https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/list?view=azure-devops-rest-6.0)

--- a/Docs/Help/Get-ADOPSUser.md
+++ b/Docs/Help/Get-ADOPSUser.md
@@ -9,11 +9,17 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Fetch user(s) by name or descriptor
+Fetch one or more users
 
 ## SYNTAX
 
-### Name (Default)
+### All (Default)
+
+```
+Get-ADOPSUser [-Organization <String>] [<CommonParameters>]
+```
+
+### Name
 
 ```
 Get-ADOPSUser [-Name] <String> [-Organization <String>] [<CommonParameters>]
@@ -34,12 +40,20 @@ Fetch user(s) by name or descriptor
 ### Example 1
 
 ```powershell
+PS C:\> Get-ADOPSUser
+```
+
+Fetch all users.
+
+### Example 2
+
+```powershell
 PS C:\> Get-ADOPSUser -Name 'john doe'
 ```
 
 Search for anyone that has `john doe` in it's name, display name or email.
 
-### Example 2
+### Example 3
 
 ```powershell
 PS C:\> Get-ADOPSUser -Descriptor 'aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U'
@@ -115,4 +129,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 https://docs.microsoft.com/en-us/rest/api/azure/devops/memberentitlementmanagement/user-entitlements/search-user-entitlements?view=azure-devops-rest-6.0
 
-https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/get?view=azure-devops-rest-6.0&viewFallbackFrom=azure-devops-rest-7.0
+https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/get?view=azure-devops-rest-6.0
+
+https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/list?view=azure-devops-rest-6.0

--- a/Source/Private/InvokeADOPSRestMethod.ps1
+++ b/Source/Private/InvokeADOPSRestMethod.ps1
@@ -13,7 +13,10 @@ function InvokeADOPSRestMethod {
         [string]$Organization,
 
         [Parameter()]
-        [string]$ContentType = 'application/json'
+        [string]$ContentType = 'application/json',
+
+        [Parameter()]
+        [switch]$FullResponse
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {
@@ -33,11 +36,19 @@ function InvokeADOPSRestMethod {
     if (-not [string]::IsNullOrEmpty($Body)) {
         $InvokeSplat.Add('Body', $Body)
     }
+
+    if ($FullResponse) {
+        $InvokeSplat.Add('ResponseHeadersVariable', 'ResponseHeaders')
+        $InvokeSplat.Add('StatusCodeVariable', 'ResponseStatusCode')
+    }
     
     $Result = Invoke-RestMethod @InvokeSplat
 
     if ($Result -like "*Azure DevOps Services | Sign In*") {
         throw 'Failed to call Azure DevOps API. Please login before using.'
+    }
+    elseif ($FullResponse) {
+        @{ Content = $Result; Headers = $ResponseHeaders; StatusCode = $ResponseStatusCode }
     }
     else {
         $Result

--- a/Source/Public/Get-ADOPSUser.ps1
+++ b/Source/Public/Get-ADOPSUser.ps1
@@ -32,9 +32,9 @@ function Get-ADOPSUser {
         if($Response.Headers.ContainsKey('X-MS-ContinuationToken')) {
             Write-Verbose "Found continuationToken. Will fetch more users."
             $parameters = [hashtable]$PSBoundParameters
-            $parameters.Add('ContinuationToken', "$($Response.Headers['X-MS-ContinuationToken'])")
+            $parameters.Add('ContinuationToken', $Response.Headers['X-MS-ContinuationToken']?[0])
             $Users.AddRange((Get-ADOPSUser @parameters))
-        }
+        }   
         Write-Output $Users
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Name') {

--- a/Source/Public/Get-ADOPSUser.ps1
+++ b/Source/Public/Get-ADOPSUser.ps1
@@ -1,0 +1,31 @@
+function Get-ADOPSUser {
+    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    param (
+        [Parameter(Mandatory, ParameterSetName = 'Name', Position = 0)]
+        [string]$Name,
+        [Parameter(Mandatory, ParameterSetName = 'Descriptor', Position = 0)]
+        [string]$Descriptor,
+        [Parameter()]
+        [string]$Organization
+    )
+
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $Org = GetADOPSHeader -Organization $Organization
+    }
+    else {
+        $Org = GetADOPSHeader
+        $Organization = $Org['Organization']
+    }
+
+    if($PSCmdlet.ParameterSetName -eq 'Name') {
+        $Uri = "https://vsaex.dev.azure.com/$Organization/_apis/UserEntitlements?`$filter=name eq '$Name'&`$orderBy=name Ascending&api-version=6.0-preview.3"
+        $Method = 'GET'
+        $Users = (InvokeADOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization).members.user
+        Write-Output $Users
+    } elseif ($PSCmdlet.ParameterSetName -eq 'Descriptor') {
+        $Uri = "https://vssps.dev.azure.com/$Organization/_apis/graph/users/$Descriptor`?api-version=6.0-preview.1"
+        $Method = 'GET'
+        $User = (InvokeADOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization)
+        Write-Output $User
+    }
+}

--- a/Source/Public/Get-ADOPSUser.ps1
+++ b/Source/Public/Get-ADOPSUser.ps1
@@ -1,12 +1,14 @@
 function Get-ADOPSUser {
-    [CmdletBinding(DefaultParameterSetName = 'Name')]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         [Parameter(Mandatory, ParameterSetName = 'Name', Position = 0)]
         [string]$Name,
         [Parameter(Mandatory, ParameterSetName = 'Descriptor', Position = 0)]
         [string]$Descriptor,
         [Parameter()]
-        [string]$Organization
+        [string]$Organization,
+        [Parameter(ParameterSetName = 'Default', DontShow)]
+        [string]$ContinuationToken
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {
@@ -17,12 +19,31 @@ function Get-ADOPSUser {
         $Organization = $Org['Organization']
     }
 
-    if($PSCmdlet.ParameterSetName -eq 'Name') {
+    if ($PSCmdlet.ParameterSetName -eq 'Default') {
+        $Uri = "https://vssps.dev.azure.com/$Organization/_apis/graph/users?api-version=6.0-preview.1"
+        $Method = 'GET'
+        if(-not [string]::IsNullOrEmpty($ContinuationToken)) {
+            $Uri += "&continuationToken=$ContinuationToken"
+        }
+        $Response = (InvokeADOPSRestMethod -FullResponse -Uri $Uri -Method $Method -Organization $Organization)
+        $Users = [System.Collections.ArrayList]::new(1000)
+        $Users.AddRange($Response.Content.value)
+        Write-Verbose "Found $($Response.Content.count) users"
+        if($Response.Headers.ContainsKey('X-MS-ContinuationToken')) {
+            Write-Verbose "Found continuationToken. Will fetch more users."
+            $parameters = [hashtable]$PSBoundParameters
+            $parameters.Add('ContinuationToken', "$($Response.Headers['X-MS-ContinuationToken'])")
+            $Users.AddRange((Get-ADOPSUser @parameters))
+        }
+        Write-Output $Users
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq 'Name') {
         $Uri = "https://vsaex.dev.azure.com/$Organization/_apis/UserEntitlements?`$filter=name eq '$Name'&`$orderBy=name Ascending&api-version=6.0-preview.3"
         $Method = 'GET'
         $Users = (InvokeADOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization).members.user
         Write-Output $Users
-    } elseif ($PSCmdlet.ParameterSetName -eq 'Descriptor') {
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq 'Descriptor') {
         $Uri = "https://vssps.dev.azure.com/$Organization/_apis/graph/users/$Descriptor`?api-version=6.0-preview.1"
         $Method = 'GET'
         $User = (InvokeADOPSRestMethod -Uri $Uri -Method $Method -Organization $Organization)

--- a/Tests/Get-ADOPSUser.Tests.ps1
+++ b/Tests/Get-ADOPSUser.Tests.ps1
@@ -12,6 +12,103 @@ Describe "Get-ADOPSUser" {
         }
     }
 
+    Context "Function returns all users" {
+        BeforeAll {
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS -ParameterFilter {
+                $Uri -notlike '*continuationToken*'
+            } {
+                [PSCustomObject]@{
+                    Content    = @{
+                        value = @(
+                            @{
+                                user = @{
+                                    subjectKind    = 'user'
+                                    metaType       = 'member'
+                                    directoryAlias = 'john.doe'
+                                    domain         = 'b3435cb9-0c61-4c5f-aa9d-eb022d95b57f'
+                                    principalName  = 'john.doe@example.org'
+                                    mailAddress    = 'john.doe@example.org'
+                                    origin         = 'aad'
+                                    originId       = 'ef317b7a-1db1-4e39-a87e-856a106b4a2f'
+                                    displayName    = 'John Doe'
+                                    url            = 'https://vssps.dev.azure.com/DummyOrg/_apis/Graph/Users/aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U'
+                                    descriptor     = 'aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U'
+                                }
+                            }
+                            @{
+                                user = @{
+                                    subjectKind    = 'user'
+                                    metaType       = 'member'
+                                    directoryAlias = 'john.doe2'
+                                    domain         = '4fac19ba-89ff-4a26-9f00-ff0ea5df74e8'
+                                    principalName  = 'john.doe2@example.org'
+                                    mailAddress    = 'john.doe@example.org'
+                                    origin         = 'aad'
+                                    originId       = '47a0d6f2-dd29-4b7c-b28a-9088bbd76612'
+                                    displayName    = 'John Doe2'
+                                    url            = 'https://vssps.dev.azure.com/DummyOrg/_apis/Graph/Users/aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U2'
+                                    descriptor     = 'aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U2'
+                                }
+                            }
+                        )
+                    }
+                    StatusCode = 200
+                    Headers    = @{
+                        'X-MS-ContinuationToken' = 'page2Token'
+                    }
+                }
+            }
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS -ParameterFilter {
+                $Uri -like '*continuationToken=page2Token*'
+            } {
+                [PSCustomObject]@{
+                    Content    = @{
+                        value = @(
+                            @{
+                                user = @{
+                                    subjectKind    = 'user'
+                                    metaType       = 'member'
+                                    directoryAlias = 'john.doe3'
+                                    domain         = 'b3435cb9-0c61-4c5f-aa9d-eb022d95b57f'
+                                    principalName  = 'john.doe3@example.org'
+                                    mailAddress    = 'john.doe3@example.org'
+                                    origin         = 'aad'
+                                    originId       = '41cd5b95-508a-4d5b-b445-100d7a6890a6'
+                                    displayName    = 'John Doe3'
+                                    url            = 'https://vssps.dev.azure.com/DummyOrg/_apis/Graph/Users/aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U3'
+                                    descriptor     = 'aad.am9obiBkb2Vqb2huIGRvZWpvaG4gZG9lam9obiBkb2U'
+                                }
+                            }
+                        )
+                    }
+                    StatusCode = 200
+                    Headers    = @{}
+                }
+            }
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
+                    }
+                    Organization = 'DummyOrg'
+                }
+            }
+        }
+
+        It "Returns 3 users" {
+            $result = Get-ADOPSUser -Organization 'DummyOrg'
+            $result | Should -Not -BeNullOrEmpty
+            $result | Should -HaveCount 3
+
+        }
+
+        It 'Calls InvokeADOPSRestMethod with the correct query params' {
+            Get-ADOPSUser -Organization 'DummyOrg'
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter { $Uri -eq "https://vssps.dev.azure.com/DummyOrg/_apis/graph/users?api-version=6.0-preview.1" }
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter { $Uri -eq "https://vssps.dev.azure.com/DummyOrg/_apis/graph/users?api-version=6.0-preview.1&continuationToken=page2Token" }
+        }
+    }
+
     Context "Function returns single user by descriptor" {
         BeforeAll {
             Mock InvokeADOPSRestMethod -ModuleName ADOPS {

--- a/Tests/Get-ADOPSUser.Tests.ps1
+++ b/Tests/Get-ADOPSUser.Tests.ps1
@@ -54,7 +54,7 @@ Describe "Get-ADOPSUser" {
                     }
                     StatusCode = 200
                     Headers    = @{
-                        'X-MS-ContinuationToken' = 'page2Token'
+                        'X-MS-ContinuationToken' = @('page2Token')
                     }
                 }
             }

--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -22,7 +22,10 @@ if (Test-Path -Path "$ScriptDirectory\..\Source\Public" -PathType Container) {
             Function = $PublicFunction
             ExportedFunctions = $ExportedFunctions
         }
-        $Parameters = (Get-Command $PublicFunction).Parameters.Keys | Where-Object { $_ -notin [System.Management.Automation.Cmdlet]::CommonParameters }
+        $Parameters = (Get-Command $PublicFunction).Parameters.GetEnumerator() | Where-Object {
+            $_.Key -notin [System.Management.Automation.Cmdlet]::CommonParameters -and
+            $_.Value.Attributes.DontShow -eq $false
+        } | Select-Object -ExpandProperty Key
         foreach ($Parameter in $Parameters) {
             $ParametersTestCases += @{
                 Function = $PublicFunction


### PR DESCRIPTION
## Overview/Summary

fixes #113 

## This PR adds

1. Command `Get-ADOPSUser`

You can now find users by name, displayname, email or by descriptor

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [X] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Verified build scripts work.
- [X] Updated relevant and associated documentation.
