### PR TITLE
Add Get-ADOPSWiki and Remove-ADOPSRepository

### DIFF
--- a/Docs/Help/Get-ADOPSWiki.md
+++ b/Docs/Help/Get-ADOPSWiki.md
@@ -1,0 +1,100 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Get-ADOPSWiki
+
+## SYNOPSIS
+Gets one or more wikis from a Azure DevOps project
+
+## SYNTAX
+
+```
+Get-ADOPSWiki [[-Organization] <String>] [-Project] <String> [[-WikiId] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This command returns Azure DevOPs wikis from a project.
+If a wiki name is given it will return any wikis with that exact name.
+Wildcards are _not_ supported.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-ADOPSWiki -Project MyProject -WikiId MyProject.wiki
+```
+
+This command will return the MyProject.wiki wiki from the MyProject project.
+If no MyProjet.wiki exists it will return nothing.
+
+### Example 2
+```powershell
+PS C:\> Get-ADOPSWiki -Project MyProject
+```
+
+This command will return all wikis from the MyProject project.
+
+## PARAMETERS
+
+### -Organization
+The organization to get wikis from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+The project to get wiki(s) from
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WikiId
+Name or ID of a specific wiki to return.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/Remove-ADOPSRepository.md
+++ b/Docs/Help/Remove-ADOPSRepository.md
@@ -1,0 +1,91 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Remove-ADOPSRepository
+
+## SYNOPSIS
+Deletes a repository from an Azure DevOps organization.
+
+## SYNTAX
+
+```
+Remove-ADOPSRepository [[-Organization] <String>] [-Project] <String> [-RepositoryID] <String>
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+This command deletes a repository from an Azure DevOps organization.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-ADOPSRepository -Project MyProject -RepositoryID 1bb0b904-27b7-414d-811e-f51085e7ad02
+```
+
+This command will delete the repository with id '1bb0b904-27b7-414d-811e-f51085e7ad02' from the 'MyProject' project.
+
+## PARAMETERS
+
+### -Organization
+The organization to connect to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+The project in which the repository exists.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RepositoryID
+The repositoru ID, GUID, to delet.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Public/Get-ADOPSWiki.ps1
+++ b/Source/Public/Get-ADOPSWiki.ps1
@@ -1,0 +1,40 @@
+function Get-ADOPSWiki {
+    param (
+        [Parameter()]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter()]
+        [string]$WikiId
+    )
+ 
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $OrgInfo = GetADOPSHeader -Organization $Organization
+    }
+    else {
+        $OrgInfo = GetADOPSHeader
+        $Organization = $OrgInfo['Organization']
+    }
+
+    $BaseUri = "https://dev.azure.com/$Organization/$Project/_apis/wiki/wikis"
+    
+    if ($WikiId) {
+        $Uri = "${BaseUri}/${WikiId}?api-version=7.1-preview.2"
+    }
+    else {
+        $Uri = "${BaseUri}?api-version=7.1-preview.2"
+    }
+
+    $Method = 'Get'
+
+    $res = InvokeADOPSRestMethod -Uri $URI -Method $Method -Organization $Organization
+    
+    if ($res.psobject.properties.name -contains 'value') {
+        Write-Output -InputObject $res.value
+    }
+    else {
+        Write-Output -InputObject $res
+    }
+}

--- a/Source/Public/Remove-ADOPSRepository.ps1
+++ b/Source/Public/Remove-ADOPSRepository.ps1
@@ -1,0 +1,32 @@
+function Remove-ADOPSRepository {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [string]$RepositoryID
+    )
+
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $OrgInfo = GetADOPSHeader -Organization $Organization
+    }
+    else {
+        $OrgInfo = GetADOPSHeader
+        $Organization = $OrgInfo['Organization']
+    }
+
+    $Uri = "https://dev.azure.com/$Organization/$Project/_apis/git/repositories/$RepositoryID`?api-version=7.1-preview.1"
+    
+    $result = InvokeADOPSRestMethod -Uri $Uri -Method Delete -Organization $Organization
+
+    if ($result.psobject.properties.name -contains 'value') {
+        Write-Output -InputObject $result.value
+    }
+    else {
+        Write-Output -InputObject $result
+    }
+}

--- a/Tests/Get-ADOPSWiki.Tests.ps1
+++ b/Tests/Get-ADOPSWiki.Tests.ps1
@@ -1,0 +1,99 @@
+Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+
+Describe 'Get-ADOPSWiki' {
+    BeforeAll {
+        Mock GetADOPSHeader -ModuleName ADOPS -MockWith {
+            @{
+                Organization = "myorg"
+            }
+        }
+        Mock GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -MockWith {
+            @{
+                Organization = "anotherOrg"
+            }
+        }
+        
+        Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
+    }
+
+    Context "General function tests" {
+        It "Function exist" {
+            { Get-Command -Name Get-ADOPSWiki -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It "Contains non mandatory parameter: <_>" -TestCases 'Organization', 'WikiId' {
+            Get-Command -Name Get-ADOPSWiki | Should -HaveParameter $_
+        }
+
+        It "Contains non mandatory parameter: <_>" -TestCases 'Project' {
+            Get-Command -Name Get-ADOPSWiki | Should -HaveParameter $_ -Mandatory
+        }
+    }
+
+    Context "Functionality" {
+
+        It 'Should get organization from GetADOPSHeader when organization parameter is used' {
+            Get-ADOPSWiki -Organization 'anotherorg' -Project 'myproj' 
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -Times 1 -Exactly
+        }
+
+        It 'Should validate organization using GetADOPSHeader when organization parameter is not used' {
+            Get-ADOPSWiki -Project 'myproj'
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -Times 0 -Exactly
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -Times 1 -Exactly
+        }
+
+        It 'If result has a value member, it should be returned' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                [PSCustomObject]@{
+                    value = @(
+                        @{
+                            name = "HasValue"
+                        }
+                    )
+                    count = 1
+                }
+            }
+
+            $r = Get-ADOPSWiki -Project 'myproj'
+            $r.name | Should -Be 'HasValue'
+        }
+
+        It 'If result does not have value member, it should be returned' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                [PSCustomObject]@{
+                    name = "HasNoValue"
+                }
+            }
+            $r = Get-ADOPSWiki -Project 'myproj'
+            $r.name | Should -Be 'HasNoValue'
+        }
+        
+        It 'Verifying URI, no WikiID given' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return $URI
+            }
+
+            $r = Get-ADOPSWiki -Project 'myproj'
+            $r | Should -Be 'https://dev.azure.com/myorg/myproj/_apis/wiki/wikis?api-version=7.1-preview.2'
+        }
+
+        It 'Verifying URI, WikiID given' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return $URI
+            }
+
+            $r = Get-ADOPSWiki -Project 'myproj' -WikiId 'MyWiki'
+            $r | Should -Be 'https://dev.azure.com/myorg/myproj/_apis/wiki/wikis/MyWiki?api-version=7.1-preview.2'
+        }
+
+        It 'Verifying method' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return $Method
+            }
+            $r = Get-ADOPSWiki -Project 'myproj'
+            $r | Should -Be 'Get'
+        }
+    }
+}


### PR DESCRIPTION
Closes #121 
Closes #122 

Adds functionality to get wikis, 
and delete repositories.

Both of these are needed to remove Project wikis.