### PR TITLE
Consistent parameter ordering and formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = unset

--- a/Docs/Help/Connect-ADOPS.md
+++ b/Docs/Help/Connect-ADOPS.md
@@ -13,7 +13,7 @@ Establish a connection to Azure DevOps using a PAT.
 
 ## SYNTAX
 
-```powershell
+```
 Connect-ADOPS [-Username] <String> [-PersonalAccessToken] <String> [-Organization] <String> [-Default]
  [<CommonParameters>]
 ```
@@ -109,7 +109,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Disconnect-ADOPS.md
+++ b/Docs/Help/Disconnect-ADOPS.md
@@ -13,7 +13,7 @@ Remove an established connection to Azure DevOps.
 
 ## SYNTAX
 
-```powershell
+```
 Disconnect-ADOPS [[-Organization] <String>] [<CommonParameters>]
 ```
 
@@ -60,7 +60,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Get-ADOPSElasticPool.md
+++ b/Docs/Help/Get-ADOPSElasticPool.md
@@ -13,7 +13,7 @@ Gets one or more Azure DevOps Elastic Pools.
 ## SYNTAX
 
 ```
-Get-ADOPSElasticPool [[-Organization] <String>] [[-PoolId] <Int32>] [<CommonParameters>]
+Get-ADOPSElasticPool [[-PoolId] <Int32>] [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -46,7 +46,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -61,7 +61,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/Get-ADOPSNode.md
+++ b/Docs/Help/Get-ADOPSNode.md
@@ -13,7 +13,7 @@ Get one or more Elastic nodes currently in the Elastic pool.
 ## SYNTAX
 
 ```
-Get-ADOPSNode [[-Organization] <String>] [-PoolId] <Int32> [<CommonParameters>]
+Get-ADOPSNode [-PoolId] <Int32> [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -54,7 +54,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/Get-ADOPSPipeline.md
+++ b/Docs/Help/Get-ADOPSPipeline.md
@@ -24,7 +24,6 @@ Lists a specific Pipeline or all Pipelines in a Specific Project.
 ### Example 1
 ```powershell
 PS C:\> Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $Name
-
 ```
 
 Get pipeline with name $Name from $Project.
@@ -32,7 +31,6 @@ Get pipeline with name $Name from $Project.
 ### Example 2
 ```powershell
 PS C:\> Get-ADOPSPipeline -Organization $OrganizationName -Project $Project
-
 ```
 
 List all Pipelines in $Project
@@ -40,7 +38,6 @@ List all Pipelines in $Project
 ### Example 3
 ```powershell
 PS C:\> Get-ADOPSPipeline -Project $Project
-
 ```
 
 List all Pipelines in $Project and uses Default Organization.
@@ -48,7 +45,7 @@ List all Pipelines in $Project and uses Default Organization.
 ## PARAMETERS
 
 ### -Name
-Name of the pipeline. 
+Name of the pipeline.
 
 ```yaml
 Type: String

--- a/Docs/Help/Get-ADOPSPool.md
+++ b/Docs/Help/Get-ADOPSPool.md
@@ -14,17 +14,17 @@ Get one or more Azure DevOps Agent pools.
 
 ### All (Default)
 ```
-Get-ADOPSPool [-Organization <String>] [-IncludeLegacy] [<CommonParameters>]
-```
-
-### PoolName
-```
-Get-ADOPSPool [-Organization <String>] -PoolName <String> [<CommonParameters>]
+Get-ADOPSPool [-IncludeLegacy] [-Organization <String>] [<CommonParameters>]
 ```
 
 ### PoolId
 ```
-Get-ADOPSPool [-Organization <String>] -PoolId <Int32> [<CommonParameters>]
+Get-ADOPSPool -PoolId <Int32> [-Organization <String>] [<CommonParameters>]
+```
+
+### PoolName
+```
+Get-ADOPSPool -PoolName <String> [-Organization <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -128,4 +128,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
 [get-agent-pools](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/pools/get-agent-pools?view=azure-devops-rest-7.1)

--- a/Docs/Help/Get-ADOPSProject.md
+++ b/Docs/Help/Get-ADOPSProject.md
@@ -13,8 +13,8 @@ Gets one or several projects in an Azure DevOps organization.
 
 ## SYNTAX
 
-```powershell
-Get-ADOPSProject [[-Organization] <String>] [[-Project] <String>] [<CommonParameters>]
+```
+Get-ADOPSProject [[-Project] <String>] [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -51,7 +51,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -67,14 +67,13 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Get-ADOPSRepository.md
+++ b/Docs/Help/Get-ADOPSRepository.md
@@ -13,8 +13,8 @@ Gets one or more repositories from a project in Azure DevOps.
 
 ## SYNTAX
 
-```powershell
-Get-ADOPSRepository [[-Organization] <String>] [-Project] <String> [[-Repository] <String>]
+```
+Get-ADOPSRepository [-Project] <String> [[-Repository] <String>] [[-Organization] <String>]
  [<CommonParameters>]
 ```
 
@@ -52,7 +52,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -68,7 +68,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -84,14 +84,13 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Get-ADOPSServiceConnection.md
+++ b/Docs/Help/Get-ADOPSServiceConnection.md
@@ -25,7 +25,6 @@ Lists a specific ServiceConnection or all ServiceConnections in a Project.
 ### Example 1
 ```powershell
 PS C:\> Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $Name
-
 ```
 
 Get ServiceConnection with name $Name from $Project.
@@ -33,7 +32,6 @@ Get ServiceConnection with name $Name from $Project.
 ### Example 2
 ```powershell
 PS C:\> Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project
-
 ```
 
 List all ServiceConnection in $Project
@@ -41,7 +39,6 @@ List all ServiceConnection in $Project
 ### Example 3
 ```powershell
 PS C:\> Get-ADOPSServiceConnection -Project $Project
-
 ```
 
 List all ServiceConnection in $Project and uses Default Organization.
@@ -49,7 +46,7 @@ List all ServiceConnection in $Project and uses Default Organization.
 ## PARAMETERS
 
 ### -Name
-Name of the ServiceConnection.
+{{ Fill Name Description }}
 
 ```yaml
 Type: String

--- a/Docs/Help/Get-ADOPSUser.md
+++ b/Docs/Help/Get-ADOPSUser.md
@@ -13,20 +13,17 @@ Fetch one or more users
 
 ## SYNTAX
 
-### All (Default)
-
+### Default (Default)
 ```
 Get-ADOPSUser [-Organization <String>] [<CommonParameters>]
 ```
 
 ### Name
-
 ```
 Get-ADOPSUser [-Name] <String> [-Organization <String>] [<CommonParameters>]
 ```
 
 ### Descriptor
-
 ```
 Get-ADOPSUser [-Descriptor] <String> [-Organization <String>] [<CommonParameters>]
 ```
@@ -112,7 +109,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Get-ADOPSWiki.md
+++ b/Docs/Help/Get-ADOPSWiki.md
@@ -13,7 +13,7 @@ Gets one or more wikis from a Azure DevOps project
 ## SYNTAX
 
 ```
-Get-ADOPSWiki [[-Organization] <String>] [-Project] <String> [[-WikiId] <String>] [<CommonParameters>]
+Get-ADOPSWiki [-Project] <String> [[-WikiId] <String>] [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,7 +49,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -64,7 +64,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -79,7 +79,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/Import-ADOPSRepository.md
+++ b/Docs/Help/Import-ADOPSRepository.md
@@ -14,13 +14,13 @@ Import an external public git repo to Azure DevOps repos.
 
 ### RepositoryName (Default)
 ```
-Import-ADOPSRepository [-Organization <Object>] -Project <String> -GitSource <Object> -RepositoryName <Object>
+Import-ADOPSRepository -GitSource <String> -RepositoryName <String> -Project <String> [-Organization <String>]
  [<CommonParameters>]
 ```
 
 ### RepositoryId
 ```
-Import-ADOPSRepository [-Organization <Object>] -Project <String> -GitSource <Object> -RepositoryId <Object>
+Import-ADOPSRepository -GitSource <String> -RepositoryId <String> -Project <String> [-Organization <String>]
  [<CommonParameters>]
 ```
 
@@ -43,7 +43,7 @@ This command will import all data from the `https://github.com/AZDOPS/AZDOPS.git
 The source repo to fetch. Must be a public accessable http or https link.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -58,7 +58,7 @@ Accept wildcard characters: False
 Your Azure DevOps organization.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -89,7 +89,7 @@ Repository id where to import the GitSource.
 This must be an empty Azure DevOps repository.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: RepositoryId
 Aliases:
 
@@ -105,7 +105,7 @@ Repository name where to import the GitSource.
 This must be an empty Azure DevOps repository.
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: RepositoryName
 Aliases:
 

--- a/Docs/Help/New-ADOPSElasticPool.md
+++ b/Docs/Help/New-ADOPSElasticPool.md
@@ -13,8 +13,8 @@ Create an Azure DevOps Elastic pool.
 ## SYNTAX
 
 ```
-New-ADOPSElasticPool [-PoolName] <String> [-ElasticPoolObject] [[-Organization] <String>] [[-ProjectId] <Guid>]
- [[-AuthorizeAllPipelines] <Boolean>] [[-AutoProvisionProjectPools] <Boolean>] [<CommonParameters>]
+New-ADOPSElasticPool [-PoolName] <String> [-ElasticPoolObject] <Object> [[-ProjectId] <String>]
+ [-AuthorizeAllPipelines] [-AutoProvisionProjectPools] [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -48,11 +48,11 @@ New-ADOPSElasticPool @Params -ElasticPoolObject @"
 }
 "@
 ```
+
 To find your serviceEndpointScope, use Get-ADOPSProject as the scope is the project where the Service connection is bound.
 Create a Azure DevOps Elastic pool that Auto provisions in project and Authorizes the pool to be consumed by all pipelines.
 It also attaches to a Virtual Machine Scale Set using the azureId.
 Full description of the request body can be found at: https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/elasticpools/create?view=azure-devops-rest-7.1
-
 
 ### Example 2
 ```powershell
@@ -66,22 +66,24 @@ $ElasticPoolObject = New-ADOPSElasticPoolObject -ServiceEndpointId '44868479-e85
 
 New-ADOPSElasticPool @Params -ElasticPoolObject $ElasticPoolObject
 ```
+
 To find your serviceEndpointScope, use Get-ADOPSProject as the scope is the project where the Service connection is bound.
 Create a Azure DevOps Elastic pool that Auto provisions in project and Authorizes the pool to be consumed by all pipelines.
 It also attaches to a Virtual Machine Scale Set using the azureId.
 Full description of the request body can be found at: https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/elasticpools/create?view=azure-devops-rest-7.1
+
 ## PARAMETERS
 
 ### -AuthorizeAllPipelines
 Setting to determine if all pipelines are authorized to use this TaskAgentPool by default.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -91,19 +93,19 @@ Accept wildcard characters: False
 Setting to automatically provision TaskAgentQueues in every project for the new pool.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -ElasticPoolObject
-The full request body in json or as a pscustom object. 
+The full request body in json or as a pscustom object.
 The Help function New-ElasticPoolObject can help generate a powershell object/json string.
 
 | Name                 | Type                | Description                                                                   |
@@ -125,6 +127,7 @@ The Help function New-ElasticPoolObject can help generate a powershell object/js
 | timeToLiveMinutes    | integer             | The minimum time in minutes to keep idle agents alive                         |
 
 ```yaml
+Type: Object
 Parameter Sets: (All)
 Aliases:
 
@@ -144,7 +147,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -169,12 +172,12 @@ Accept wildcard characters: False
 If provided, a new TaskAgentQueue will be created in the specified project.
 
 ```yaml
-Type: Guid
+Type: String
 Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -193,4 +196,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
 [elasticpools-create](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/elasticpools/create?view=azure-devops-rest-7.1)

--- a/Docs/Help/New-ADOPSElasticPoolObject.md
+++ b/Docs/Help/New-ADOPSElasticPoolObject.md
@@ -16,7 +16,7 @@ Creates an Elastic pool object that can be used.
 New-ADOPSElasticPoolObject [-ServiceEndpointId] <Guid> [-ServiceEndpointScope] <Guid> [-AzureId] <String>
  [[-OsType] <String>] [[-MaxCapacity] <Int32>] [[-DesiredIdle] <Int32>] [[-RecycleAfterEachUse] <Boolean>]
  [[-DesiredSize] <Int32>] [[-AgentInteractiveUI] <Boolean>] [[-TimeToLiveMinues] <Int32>]
- [[-MaxSavedNodeCount] <Int32>] [<CommonParameters>]
+ [[-MaxSavedNodeCount] <Int32>] [[-OutputType] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -27,7 +27,7 @@ Creates an Elastic pool object that can be used.
 ### Example 1
 ```powershell
 $AzureDevOpsProject = Get-ADOPSProject -Project 'Azure'
-$AzureVMSS = Get-AzVmss -VMScaleSetName 'vmss-test' 
+$AzureVMSS = Get-AzVmss -VMScaleSetName 'vmss-test'
 New-ADOPSElasticPoolObject -ServiceEndpointId '44868479-e856-42bf-9a2b-74bb500d8e36' -ServiceEndpointScope $AzureDevOpsProject.Id -AzureId $AzureVMSS.id
 ```
 
@@ -68,7 +68,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -141,11 +141,27 @@ Operating system type of the nodes in the pool
 Type: String
 Parameter Sets: (All)
 Aliases:
-Accepted values: Linux, Windows
+Accepted values: linux, windows
 
 Required: False
-Position: 2
+Position: 3
 Default value: linux
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputType
+In what format should the output be in.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: json, pscustomobject
+
+Required: False
+Position: 11
+Default value: pscustomobject
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -210,22 +226,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OutputType
-In what format should the output be in.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-Accepted values: json, pscustomobject
-
-Required: False
-Position: 10
-Default value: pscustomobject
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -239,4 +239,5 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
 [elasticpools-create](https://docs.microsoft.com/en-us/rest/api/azure/devops/distributedtask/elasticpools/create?view=azure-devops-rest-7.1)

--- a/Docs/Help/New-ADOPSPipeline.md
+++ b/Docs/Help/New-ADOPSPipeline.md
@@ -38,8 +38,24 @@ Create pipeline in $ProjectName and use Default Organization and put the pipelin
 
 ## PARAMETERS
 
+### -FolderPath
+Folderpath to add your pipelines to under Devops Pipelines.
+Like: PipelineFolder or PipelineFolder1\PipelineSubFolder2
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Name
-Name of the pipeline. 
+Name of the pipeline.
 
 ```yaml
 Type: String
@@ -63,22 +79,6 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -FolderPath
-Folderpath to add your pipelines to under Devops Pipelines.
-Like: PipelineFolder or PipelineFolder1\PipelineSubFolder2
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/New-ADOPSProject.md
+++ b/Docs/Help/New-ADOPSProject.md
@@ -13,7 +13,7 @@ Creates a new project in Azure DevOps.
 
 ## SYNTAX
 
-```powershell
+```
 New-ADOPSProject [-Name] <String> [[-Description] <String>] [-Visibility] <String>
  [[-SourceControlType] <String>] [[-ProcessTypeName] <String>] [[-Organization] <String>] [<CommonParameters>]
 ```
@@ -50,22 +50,6 @@ Creates a new, private project called "ADOPSproj" with an existing, custom proce
 
 ## PARAMETERS
 
-### -Name
-
-The name of the new project.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 0
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Description
 
 The description of the new project.
@@ -82,6 +66,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Name
+
+The name of the new project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Organization
 
 The organization to create the project in.
@@ -93,23 +93,6 @@ Aliases:
 
 Required: False
 Position: 5
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Visibility
-
-The visibility of the project.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-Accepted values: Private, Public
-
-Required: True
-Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -150,8 +133,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### CommonParameters
+### -Visibility
 
+The visibility of the project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Private, Public
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/New-ADOPSRepository.md
+++ b/Docs/Help/New-ADOPSRepository.md
@@ -13,7 +13,7 @@ Create a new Azure DevOps Git repository
 ## SYNTAX
 
 ```
-New-ADOPSRepository [[-Organization] <String>] [-Project] <String> [-Name] <String> [<CommonParameters>]
+New-ADOPSRepository [-Name] <String> [-Project] <String> [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -54,7 +54,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -14,7 +14,7 @@ Create an Azure DevOps Service Connection to Azure.
 
 ```
 New-ADOPSServiceConnection [-TenantId] <String> [-SubscriptionName] <String> [-SubscriptionId] <String>
- [-Project] <String> [[-ConnectionName] <String>] [[-Organization] <String>] [-ServicePrincipal] <PSCredential>
+ [-Project] <String> [[-ConnectionName] <String>] [-ServicePrincipal] <PSCredential> [[-Organization] <String>]
  [<CommonParameters>]
 ```
 
@@ -64,7 +64,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 6
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -94,7 +94,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 6
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/New-ADOPSUserStory.md
+++ b/Docs/Help/New-ADOPSUserStory.md
@@ -13,8 +13,8 @@ Create User Story in DevOps Project
 ## SYNTAX
 
 ```
-New-ADOPSUserStory -Organization <String> -ProjectName <String> -Title <String> [-Description <String>]
- [-Tags <String>] [-Priority <String>] [<CommonParameters>]
+New-ADOPSUserStory [-Title] <String> [-ProjectName] <String> [[-Description] <String>] [[-Tags] <String>]
+ [[-Priority] <String>] [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -47,7 +47,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -61,8 +61,8 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
-Position: Named
+Required: False
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -77,7 +77,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 4
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -92,7 +92,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -107,7 +107,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: Named
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -122,7 +122,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/New-ADOPSVariableGroup.md
+++ b/Docs/Help/New-ADOPSVariableGroup.md
@@ -13,18 +13,16 @@ Creates a new variable group in an Azure DevOps project.
 
 ## SYNTAX
 
-### VariableHashtable
-
-```powershell
-New-ADOPSVariableGroup [-Organization <String>] -Project <String> -VariableGroupName <String>
- [-Description <String>] [-VariableHashtable <Hashtable[]>] [<CommonParameters>]
+### VariableSingle
+```
+New-ADOPSVariableGroup -VariableGroupName <String> -VariableName <String> -VariableValue <String>
+ -Project <String> [-IsSecret] [-Description <String>] [-Organization <String>] [<CommonParameters>]
 ```
 
-### VariableSingle
-
-```powershell
-New-ADOPSVariableGroup [-Organization <String>] -Project <String> -VariableGroupName <String>
- [-VariableName <String>] [-VariableValue <String>] [-IsSecret] [-Description <String>] [<CommonParameters>]
+### VariableHashtable
+```
+New-ADOPSVariableGroup -VariableGroupName <String> -Project <String> -VariableHashtable <Hashtable[]>
+ [-Description <String>] [-Organization <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,7 +42,7 @@ PS C:\> $Hashtable = @(
                 value    = "Key1Value"
                 IsSecret = $true
             },
-            @{       
+            @{
                 Name     = "Key2"
                 value    = "Key2Value"
                 IsSecret = $false
@@ -150,7 +148,8 @@ Accept wildcard characters: False
 
 A hashtable containing the variable to be created with the variable group.
 
-```powershell
+
+
 @(
     @{
         Name     = "Key1"
@@ -163,10 +162,9 @@ A hashtable containing the variable to be created with the variable group.
         IsSecret = $false
     }
 )
-```
 
 ```yaml
-Type: Hashtable
+Type: Hashtable[]
 Parameter Sets: VariableHashtable
 Aliases:
 
@@ -210,7 +208,6 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/New-ADOPSWiki.md
+++ b/Docs/Help/New-ADOPSWiki.md
@@ -14,8 +14,8 @@ Creates a new Azure DevOps code wiki.
 ## SYNTAX
 
 ```
-New-ADOPSWiki [[-Organization] <String>] [-Project] <String> [-WikiName] <String> [-WikiRepository] <String>
- [[-WikiRepositoryPath] <String>] [[-GitBranch] <String>] [<CommonParameters>]
+New-ADOPSWiki [-WikiName] <String> [-WikiRepository] <String> [-Project] <String>
+ [[-WikiRepositoryPath] <String>] [[-GitBranch] <String>] [[-Organization] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,7 +57,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: 4
 Default value: Main
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -73,7 +73,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 5
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -89,7 +89,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -105,7 +105,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -121,7 +121,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -137,14 +137,13 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: 3
 Default value: '/'
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Remove-ADOPSRepository.md
+++ b/Docs/Help/Remove-ADOPSRepository.md
@@ -13,7 +13,7 @@ Deletes a repository from an Azure DevOps organization.
 ## SYNTAX
 
 ```
-Remove-ADOPSRepository [[-Organization] <String>] [-Project] <String> [-RepositoryID] <String>
+Remove-ADOPSRepository [-RepositoryID] <String> [-Project] <String> [[-Organization] <String>]
  [<CommonParameters>]
 ```
 
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -70,7 +70,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/Remove-ADOPSVariableGroup.md
+++ b/Docs/Help/Remove-ADOPSVariableGroup.md
@@ -13,8 +13,8 @@ Removes a variable group from Azure DevOps.
 
 ## SYNTAX
 
-```powershell
-Remove-ADOPSVariableGroup [[-Organization] <String>] [-Project] <String> [-VariableGroupName] <String>
+```
+Remove-ADOPSVariableGroup [-VariableGroupName] <String> [-Project] <String> [[-Organization] <String>]
  [<CommonParameters>]
 ```
 
@@ -52,7 +52,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -84,14 +84,13 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/Docs/Help/Set-ADOPSElasticPool.md
+++ b/Docs/Help/Set-ADOPSElasticPool.md
@@ -37,7 +37,7 @@ Generates a Elastic pool object using the New-ADOPSElasticPoolObject function an
 ## PARAMETERS
 
 ### -ElasticPoolObject
-The full request body in json or as a pscustom object. 
+The full request body in json or as a pscustom object.
 The Help function New-ElasticPoolObject can help generate a powershell object/json string.
 
 | Name                 | Type                | Description                                                                   |

--- a/Docs/Help/Start-ADOPSPipeline.md
+++ b/Docs/Help/Start-ADOPSPipeline.md
@@ -13,7 +13,7 @@ Starts an Azure DevOps Pipeline.
 ## SYNTAX
 
 ```
-Start-ADOPSPipeline [-Name] <String> [-Project] <String> [[-Organization] <String>] [[-Branch] <String>]
+Start-ADOPSPipeline [-Name] <String> [-Project] <String> [[-Branch] <String>] [[-Organization] <String>]
  [<CommonParameters>]
 ```
 
@@ -40,7 +40,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 3
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -70,7 +70,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/Test-ADOPSYamlFile.md
+++ b/Docs/Help/Test-ADOPSYamlFile.md
@@ -13,7 +13,7 @@ Test a yaml file against the Azure DevOps schema validator.
 ## SYNTAX
 
 ```
-Test-ADOPSYamlFile [[-Organization] <String>] [-Project] <String> [-File] <String> [-PipelineId] <Int32>
+Test-ADOPSYamlFile [-Project] <String> [-File] <String> [-PipelineId] <Int32> [[-Organization] <String>]
  [<CommonParameters>]
 ```
 
@@ -44,7 +44,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 2
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -59,19 +59,19 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 0
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### -PipelineId
-Pipeline Id to run the verification against. 
+Pipeline Id to run the verification against.
 Can be found by running the command
 
-```PowerShell
+
+
 Get-ADOPSPipeline -Project MyProject -Name MyPipelineName
-```
 
 ```yaml
 Type: Int32
@@ -79,7 +79,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -94,7 +94,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Source/Public/Get-ADOPSElasticPool.ps1
+++ b/Source/Public/Get-ADOPSElasticPool.ps1
@@ -2,11 +2,10 @@ function Get-ADOPSElasticPool {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [string]$Organization,
+        [int32]$PoolId,
 
         [Parameter()]
-        [int32]$PoolId
-
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Get-ADOPSNode.ps1
+++ b/Source/Public/Get-ADOPSNode.ps1
@@ -1,11 +1,11 @@
 function Get-ADOPSNode {
     [CmdletBinding()]
     param (
-        [Parameter()]
-        [string]$Organization,
-
         [Parameter(Mandatory)]
-        [int32]$PoolId
+        [int32]$PoolId,
+
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Get-ADOPSPool.ps1
+++ b/Source/Public/Get-ADOPSPool.ps1
@@ -1,27 +1,18 @@
 function Get-ADOPSPool {
     [CmdletBinding(DefaultParameterSetName = 'All')]
     param (
-        [Parameter(ParameterSetName = 'PoolId')]
-        [Parameter(ParameterSetName = 'PoolName')]
-        [Parameter(ParameterSetName = 'All')]
-        [string]$Organization,
-
-        [Parameter(
-            Mandatory = $true,
-            ParameterSetName = 'PoolId'
-        )]
+        [Parameter(Mandatory, ParameterSetName = 'PoolId')]
         [int32]$PoolId,
 
-        [Parameter(
-            Mandatory = $true,
-            ParameterSetName = 'PoolName'
-        )]
+        [Parameter(Mandatory, ParameterSetName = 'PoolName')]
         [string]$PoolName,
 
         # Include legacy pools
         [Parameter(ParameterSetName = 'All')]
-        [switch]
-        $IncludeLegacy
+        [switch]$IncludeLegacy,
+
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Get-ADOPSProject.ps1
+++ b/Source/Public/Get-ADOPSProject.ps1
@@ -2,10 +2,10 @@ function Get-ADOPSProject {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [string]$Organization,
+        [string]$Project,
 
         [Parameter()]
-        [string]$Project
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Get-ADOPSRepository.ps1
+++ b/Source/Public/Get-ADOPSRepository.ps1
@@ -1,13 +1,14 @@
 function Get-ADOPSRepository {
     [CmdletBinding()]
     param(
-        [Parameter()]
-        [string]$Organization,
-
         [Parameter(Mandatory)]
         [string]$Project,
 
-        [string]$Repository
+        [Parameter()]
+        [string]$Repository,
+
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Get-ADOPSUser.ps1
+++ b/Source/Public/Get-ADOPSUser.ps1
@@ -3,10 +3,13 @@ function Get-ADOPSUser {
     param (
         [Parameter(Mandatory, ParameterSetName = 'Name', Position = 0)]
         [string]$Name,
+
         [Parameter(Mandatory, ParameterSetName = 'Descriptor', Position = 0)]
         [string]$Descriptor,
+
         [Parameter()]
         [string]$Organization,
+
         [Parameter(ParameterSetName = 'Default', DontShow)]
         [string]$ContinuationToken
     )

--- a/Source/Public/Get-ADOPSWiki.ps1
+++ b/Source/Public/Get-ADOPSWiki.ps1
@@ -1,13 +1,13 @@
 function Get-ADOPSWiki {
     param (
-        [Parameter()]
-        [string]$Organization,
-
         [Parameter(Mandatory)]
         [string]$Project,
 
         [Parameter()]
-        [string]$WikiId
+        [string]$WikiId,
+
+        [Parameter()]
+        [string]$Organization
     )
  
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Import-ADOPSRepository.ps1
+++ b/Source/Public/Import-ADOPSRepository.ps1
@@ -1,24 +1,20 @@
 function Import-ADOPSRepository {
     [CmdLetBinding(DefaultParameterSetName='RepositoryName')]
     param (
-        [Parameter(ParameterSetName = 'RepositoryName')]
-        [Parameter(ParameterSetName = 'RepositoryId')]
-        $Organization,
+        [Parameter(Mandatory)]
+        [string]$GitSource,
 
+        [Parameter(Mandatory, ParameterSetName = 'RepositoryId')]
+        [string]$RepositoryId,
         
         [Parameter(Mandatory, ParameterSetName = 'RepositoryName')]
-        [Parameter(Mandatory, ParameterSetName = 'RepositoryId')]
+        [string]$RepositoryName,
+
+        [Parameter(Mandatory)]
         [string]$Project,
 
-        [Parameter(Mandatory, ParameterSetName = 'RepositoryName')]
-        [Parameter(Mandatory, ParameterSetName = 'RepositoryId')]
-        $GitSource,
-        
-        [Parameter(Mandatory, ParameterSetName = 'RepositoryId')]
-        $RepositoryId,
-        
-        [Parameter(Mandatory, ParameterSetName = 'RepositoryName')]
-        $RepositoryName
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/New-ADOPSElasticpool.ps1
+++ b/Source/Public/New-ADOPSElasticpool.ps1
@@ -7,20 +7,17 @@ function New-ADOPSElasticPool {
         [Parameter(Mandatory)]
         $ElasticPoolObject,
 
-        [string]$Organization,
-        
         [Parameter()]
-        [string]
-        $ProjectId,
+        [string]$ProjectId,
 
         [Parameter()]
-        [boolean]
-        $AuthorizeAllPipelines = $false,
+        [switch]$AuthorizeAllPipelines,
 
         [Parameter()]
-        [boolean]
-        $AutoProvisionProjectPools = $false
+        [switch]$AutoProvisionProjectPools,
 
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/New-ADOPSRepository.ps1
+++ b/Source/Public/New-ADOPSRepository.ps1
@@ -1,16 +1,16 @@
 function New-ADOPSRepository {
     param (
-        [Parameter()]
+        [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
-        [string]$Organization,
+        [string]$Name,
 
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$Project,
 
-        [Parameter(Mandatory)]
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [string]$Name
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/New-ADOPSServiceConnection.ps1
+++ b/Source/Public/New-ADOPSServiceConnection.ps1
@@ -1,26 +1,26 @@
 function New-ADOPSServiceConnection {
     [cmdletbinding()]
     param(
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]$TenantId,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]$SubscriptionName,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]$SubscriptionId,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory)]
         [string]$Project,
 
-        [parameter()]
+        [Parameter()]
         [string]$ConnectionName,
-
-        [parameter()]
-        [string]$Organization,
       
-        [Parameter(mandatory)]
-        [pscredential]$ServicePrincipal
+        [Parameter(Mandatory)]
+        [pscredential]$ServicePrincipal,
+
+        [Parameter()]
+        [string]$Organization
     )
 
     # Set organization

--- a/Source/Public/New-ADOPSUserStory.ps1
+++ b/Source/Public/New-ADOPSUserStory.ps1
@@ -1,28 +1,24 @@
 function New-ADOPSUserStory {
   [CmdletBinding()]
   param (
-
-    [Parameter(Mandatory,
-      ParameterSetName = "Default")]
-    [string]$Organization,
-
-    [Parameter(Mandatory,
-      ParameterSetName = "Default")]
-    [string]$ProjectName,
-
-    [Parameter(Mandatory,
-      ParameterSetName = "Default")]
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
     [string]$Title,
 
-    [Parameter(ParameterSetName = "Default")]
+    [Parameter(Mandatory)]
+    [string]$ProjectName,
+
+    [Parameter()]
     [string]$Description,
 
-    [Parameter(ParameterSetName = "Default")]
-    [string]$Tags,        
+    [Parameter()]
+    [string]$Tags,
 
-    [Parameter(ParameterSetName = "Default")]
-    [string]$Priority
+    [Parameter()]
+    [string]$Priority,
 
+    [Parameter()]
+    [string]$Organization
   )
 
   if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/New-ADOPSVariableGroup.ps1
+++ b/Source/Public/New-ADOPSVariableGroup.ps1
@@ -1,17 +1,7 @@
 function New-ADOPSVariableGroup {
     [CmdletBinding()]
     param (
-        [Parameter(ParameterSetName = 'VariableSingle')]
-        [Parameter(ParameterSetName = 'VariableHashtable')]
-        [string]$Organization,
-
-        [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
-
-        [Parameter(Mandatory, ParameterSetName = 'VariableHashtable')]
-        [string]$Project,
-
-        [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
-        [Parameter(Mandatory, ParameterSetName = 'VariableHashtable')]
+        [Parameter(Mandatory)]
         [string]$VariableGroupName,
 
         [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
@@ -20,11 +10,11 @@ function New-ADOPSVariableGroup {
         [Parameter(Mandatory, ParameterSetName = 'VariableSingle')]
         [string]$VariableValue,
 
+        [Parameter(Mandatory)]
+        [string]$Project,
+
         [Parameter(ParameterSetName = 'VariableSingle')]
         [switch]$IsSecret,
-
-        [Parameter()]
-        [string]$Description,
 
         [Parameter(Mandatory, ParameterSetName = 'VariableHashtable')]
         [ValidateScript(
@@ -32,7 +22,13 @@ function New-ADOPSVariableGroup {
                 $_ | ForEach-Object { $_.Keys -Contains 'Name' -and $_.Keys -Contains 'IsSecret' -and $_.Keys -Contains 'Value' -and $_.Keys.count -eq 3 }
             },
             ErrorMessage = 'The hashtable must contain the following keys: Name, IsSecret, Value')]
-        [hashtable[]]$VariableHashtable
+        [hashtable[]]$VariableHashtable,
+
+        [Parameter()]
+        [string]$Description,
+
+        [Parameter()]
+        [string]$Organization
     )
 
     if ([string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/New-ADOPSWiki.ps1
+++ b/Source/Public/New-ADOPSWiki.ps1
@@ -1,23 +1,23 @@
 function New-ADOPSWiki {
     [CmdletBinding()]
     param (
-        [Parameter()]
-        [string]$Organization,
-
-        [Parameter(Mandatory)]
-        [string]$Project,
-
         [Parameter(Mandatory)]
         [string]$WikiName,
         
         [Parameter(Mandatory)]
         [string]$WikiRepository,
 
+        [Parameter(Mandatory)]
+        [string]$Project,
+
         [Parameter()]
         [string]$WikiRepositoryPath = '/',
         
         [Parameter()]
-        [string]$GitBranch = 'main'
+        [string]$GitBranch = 'main',
+
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Remove-ADOPSRepository.ps1
+++ b/Source/Public/Remove-ADOPSRepository.ps1
@@ -1,14 +1,14 @@
 function Remove-ADOPSRepository {
     [CmdletBinding()]
     param(
-        [Parameter()]
-        [string]$Organization,
+        [Parameter(Mandatory)]
+        [string]$RepositoryID,
 
         [Parameter(Mandatory)]
         [string]$Project,
 
-        [Parameter(Mandatory)]
-        [string]$RepositoryID
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Remove-ADOPSVariableGroup.ps1
+++ b/Source/Public/Remove-ADOPSVariableGroup.ps1
@@ -1,14 +1,14 @@
 function Remove-ADOPSVariableGroup {
     [CmdletBinding()]
     param (
-        [Parameter()]
-        [string]$Organization,
+        [Parameter(Mandatory)]
+        [string]$VariableGroupName,
 
         [Parameter(Mandatory)]
         [string]$Project,
 
-        [Parameter(Mandatory)]
-        [string]$VariableGroupName
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Set-ADOPSElasticPool.ps1
+++ b/Source/Public/Set-ADOPSElasticPool.ps1
@@ -7,8 +7,8 @@ function Set-ADOPSElasticPool {
         [Parameter(Mandatory)]
         $ElasticPoolObject,
 
+        [Parameter()]
         [string]$Organization
-
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {
@@ -21,7 +21,7 @@ function Set-ADOPSElasticPool {
 
     $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools/$PoolId`?api-version=7.1-preview.1"
 
-    if ($ElasticPoolObject.gettype().name -eq 'String') {
+    if ($ElasticPoolObject.GetType().Name -eq 'String') {
         $Body = $ElasticPoolObject
     }
     else {

--- a/Source/Public/Start-ADOPSPipeline.ps1
+++ b/Source/Public/Start-ADOPSPipeline.ps1
@@ -7,10 +7,10 @@ function Start-ADOPSPipeline {
         [string]$Project,
 
         [Parameter()]
-        [string]$Organization,
+        [string]$Branch = 'main',
 
         [Parameter()]
-        [string]$Branch = 'main'
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Source/Public/Test-ADOPSYamlFile.ps1
+++ b/Source/Public/Test-ADOPSYamlFile.ps1
@@ -1,9 +1,6 @@
 function Test-ADOPSYamlFile {
     [CmdletBinding()]
     param (
-        [Parameter()]
-        [string]$Organization,
-
         [Parameter(Mandatory)]
         [string]$Project,
 
@@ -14,7 +11,10 @@ function Test-ADOPSYamlFile {
         [string]$File,
 
         [Parameter(Mandatory)]
-        [int]$PipelineId
+        [int]$PipelineId,
+
+        [Parameter()]
+        [string]$Organization
     )
 
     if (-not [string]::IsNullOrEmpty($Organization)) {

--- a/Tests/New-ADOPSElasticpool.Tests.ps1
+++ b/Tests/New-ADOPSElasticpool.Tests.ps1
@@ -65,11 +65,11 @@ Describe "New-ADOPSElasticpool" {
         }
 
         It "Returns created elastic pool" {
-            New-ADOPSElasticpool -PoolName 'CustomPool' -ElasticPoolObject $ElasticPoolObject -Organization 'DummyOrg' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true | Should -Not -BeNullOrEmpty
+            New-ADOPSElasticpool -PoolName 'CustomPool' -ElasticPoolObject $ElasticPoolObject -Organization 'DummyOrg' -AuthorizeAllPipelines -AutoProvisionProjectPools | Should -Not -BeNullOrEmpty
         }
 
         It "Returns created elastic pool id" {
-            (New-ADOPSElasticpool -PoolName 'CustomPool' -ElasticPoolObject $ElasticPoolObject -Organization 'DummyOrg' -AuthorizeAllPipelines $true -AutoProvisionProjectPools $true).elasticPool.poolid | Should -Be 59
+            (New-ADOPSElasticpool -PoolName 'CustomPool' -ElasticPoolObject $ElasticPoolObject -Organization 'DummyOrg' -AuthorizeAllPipelines -AutoProvisionProjectPools).elasticPool.poolid | Should -Be 59
         }
 
     }


### PR DESCRIPTION
# Contributing a Pull Request

## Overview/Summary

Refactors a few common parameter usages.

## This PR fixes/adds/changes/removes

1. Moved common parameter `Organization` to the end
2. Prioritized the `Project` parameter lower when the target resource is not a Project.
3. Mandatory parameters have higher priority in the order
4. Added stricter types on known parameters
5. Added .editorconfig

Specific changes:
- New-ADOPSElasticPool:
  - Changed from boolean to switch parameters
- New-ADOPSUserStory:
  - Organization is no longer mandatory

- Import-ADOPSRepository:
  - Stricter types

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Verified build scripts work.
- [X] Updated relevant and associated documentation.
