### PR TITLE
Refactor test structure

### DIFF
--- a/Tests/Assertions/HaveParameterStrict.psm1
+++ b/Tests/Assertions/HaveParameterStrict.psm1
@@ -1,0 +1,537 @@
+# Adapted from https://github.com/pester/Pester/blob/5.3.3/src/functions/assertions/HaveParameter.ps1
+# Replaced \$SafeCommands\['([\w-]*)'\] with $1
+
+#region Dependent functions
+function Format-Because ([string] $Because) {
+    if ($null -eq $Because) {
+        return
+    }
+
+    $bcs = $Because.Trim()
+    if ([string]::IsNullOrEmpty($bcs)) {
+        return
+    }
+
+    " because $($bcs -replace 'because\s'),"
+}
+function Format-Collection ($Value, [switch]$Pretty) {
+    $Limit = 10
+    $separator = ', '
+    if ($Pretty) {
+        $separator = ",`n"
+    }
+    $count = $Value.Count
+    $trimmed = $count -gt $Limit
+
+    $formattedCollection = @()
+    for ($i = 0; $i -lt [System.Math]::Min($count, $Limit); $i++) {
+        $formattedValue = Format-Nicely -Value $Value[$i] -Pretty:$Pretty
+        $formattedCollection += $formattedValue
+    }
+
+    '@(' + ($formattedCollection -join $separator) + $(if ($trimmed) { ", ...$($count - $limit) more" }) + ')'
+}
+
+function Format-Object ($Value, $Property, [switch]$Pretty) {
+    if ($null -eq $Property) {
+        $Property = $Value.PSObject.Properties | & Select-Object -ExpandProperty Name
+    }
+    $valueType = Get-ShortType $Value
+    $valueFormatted = ([string]([PSObject]$Value | & Select-Object -Property $Property))
+
+    if ($Pretty) {
+        $margin = "    "
+        $valueFormatted = $valueFormatted `
+            -replace '^@{', "@{`n$margin" `
+            -replace '; ', ";`n$margin" `
+            -replace '}$', "`n}" `
+
+    }
+
+    $valueFormatted -replace "^@", $valueType
+}
+
+function Format-Null {
+    '$null'
+}
+
+function Format-String ($Value) {
+    if ('' -eq $Value) {
+        return '<empty>'
+    }
+
+    "'$Value'"
+}
+
+function Format-Date ($Value) {
+    $Value.ToString('o')
+}
+
+function Format-Boolean ($Value) {
+    '$' + $Value.ToString().ToLower()
+}
+
+function Format-ScriptBlock ($Value) {
+    '{' + $Value + '}'
+}
+
+function Format-Number ($Value) {
+    [string]$Value
+}
+
+function Format-Hashtable ($Value) {
+    $head = '@{'
+    $tail = '}'
+
+    $entries = $Value.Keys | & Sort-Object | & ForEach-Object {
+        $formattedValue = Format-Nicely $Value.$_
+        "$_=$formattedValue" }
+
+    $head + ( $entries -join '; ') + $tail
+}
+
+function Format-Dictionary ($Value) {
+    $head = 'Dictionary{'
+    $tail = '}'
+
+    $entries = $Value.Keys | & Sort-Object | & ForEach-Object {
+        $formattedValue = Format-Nicely $Value.$_
+        "$_=$formattedValue" }
+
+    $head + ( $entries -join '; ') + $tail
+}
+
+function Format-Nicely ($Value, [switch]$Pretty) {
+    if ($null -eq $Value) {
+        return Format-Null -Value $Value
+    }
+
+    if ($Value -is [bool]) {
+        return Format-Boolean -Value $Value
+    }
+
+    if ($Value -is [string]) {
+        return Format-String -Value $Value
+    }
+
+    if ($Value -is [DateTime]) {
+        return Format-Date -Value $Value
+    }
+
+    if ($value -is [Type]) {
+        return '[' + (Format-Type -Value $Value) + ']'
+    }
+
+    if (Is-DecimalNumber -Value $Value) {
+        return Format-Number -Value $Value
+    }
+
+    if (Is-ScriptBlock -Value $Value) {
+        return Format-ScriptBlock -Value $Value
+    }
+
+    if (Is-Value -Value $Value) {
+        return $Value
+    }
+
+    if (Is-Hashtable -Value $Value) {
+        # no advanced formatting of objects in the first version, till I balance it
+        return [string]$Value
+        #return Format-Hashtable -Value $Value
+    }
+
+    if (Is-Dictionary -Value $Value) {
+        # no advanced formatting of objects in the first version, till I balance it
+        return [string]$Value
+        #return Format-Dictionary -Value $Value
+    }
+
+    if (Is-Collection -Value $Value) {
+        return Format-Collection -Value $Value -Pretty:$Pretty
+    }
+
+    # no advanced formatting of objects in the first version, till I balance it
+    return [string]$Value
+    # Format-Object -Value $Value -Property (Get-DisplayProperty $Value) -Pretty:$Pretty
+}
+
+function Sort-Property ($InputObject, [string[]]$SignificantProperties, $Limit = 4) {
+
+    $properties = @($InputObject.PSObject.Properties |
+            & Where-Object { $_.Name -notlike "_*" } |
+            & Select-Object -expand Name |
+            & Sort-Object)
+    $significant = @()
+    $rest = @()
+    foreach ($p in $properties) {
+        if ($significantProperties -contains $p) {
+            $significant += $p
+        }
+        else {
+            $rest += $p
+        }
+    }
+
+    #todo: I am assuming id, name properties, so I am just sorting the selected ones by name.
+    (@($significant | & Sort-Object) + $rest) | & Select-Object -First $Limit
+
+}
+
+function Get-DisplayProperty ($Value) {
+    Sort-Property -InputObject $Value -SignificantProperties 'id', 'name'
+}
+
+function Get-ShortType ($Value) {
+    if ($null -ne $value) {
+        $type = Format-Type $Value.GetType()
+        # PSCustomObject serializes to the whole type name on normal PS but to
+        # just PSCustomObject on PS Core
+
+        $type `
+            -replace "^System\." `
+            -replace "^Management\.Automation\.PSCustomObject$", "PSObject" `
+            -replace "^PSCustomObject$", "PSObject" `
+            -replace "^Object\[\]$", "collection" `
+
+    }
+    else {
+        Format-Type $null
+    }
+}
+
+function Format-Type ([Type]$Value) {
+    if ($null -eq $Value) {
+        return '<none>'
+    }
+
+    [string]$Value
+}
+
+function Join-And ($Items, $Threshold = 2) {
+
+    if ($null -eq $items -or $items.count -lt $Threshold) {
+        $items -join ', '
+    }
+    else {
+        $c = $items.count
+        ($items[0..($c - 2)] -join ', ') + ' and ' + $items[-1]
+    }
+}
+
+function Add-SpaceToNonEmptyString ([string]$Value) {
+    if ($Value) {
+        " $Value"
+    }
+}
+#endregion
+
+function Should-HaveParameterStrict (
+    $ActualValue,
+    [String] $ParameterName,
+    $Type,
+    [String]$DefaultValue,
+    [Switch]$Mandatory,
+    [Switch]$HasArgumentCompleter,
+    [String]$Alias,
+    [Switch]$Negate,
+    [String]$Because ) {
+    <#
+    .SYNOPSIS
+        Asserts that a command has the expected parameter.
+
+    .EXAMPLE
+        Get-Command "Invoke-WebRequest" | Should -HaveParameterStrict Uri -Mandatory
+
+        This test passes, because it expected the parameter URI to exist and to
+        be mandatory.
+    .NOTES
+        The attribute [ArgumentCompleter] was added with PSv5. Previouse this
+        assertion will not be able to use the -HasArgumentCompleter parameter
+        if the attribute does not exist.
+    #>
+    if ($null -eq $ActualValue -or $ActualValue -isnot [Management.Automation.CommandInfo]) {
+        throw "Input value must be non-null CommandInfo object. You can get one by calling Get-Command."
+    }
+
+    if ($null -eq $ParameterName) {
+        throw "The ParameterName can't be empty"
+    }
+
+    function Get-ParameterInfo {
+        param(
+            [Parameter( Mandatory = $true )]
+            [Management.Automation.CommandInfo]$Command
+        )
+        <#
+        .SYNOPSIS
+            Use Tokenize to get information about the parameter block of a command
+        .DESCRIPTION
+            In order to get information about the parameter block of a command,
+            several tools can be used (Get-Command, AST, etc).
+            In order to get the default value of a parameter, AST is the easiest
+            way to go; but AST was only introduced with PSv3.
+            This function creates an object with information about parameters
+            using the Tokenize
+        .NOTES
+            Author: Chris Dent
+        #>
+
+        function Get-TokenGroup {
+            param(
+                [Parameter( Mandatory = $true )]
+                [System.Management.Automation.PSToken[]]$tokens
+            )
+            $i = $j = 0
+            do {
+                $token = $tokens[$i]
+                if ($token.Type -eq 'GroupStart') {
+                    $j++
+                }
+                if ($token.Type -eq 'GroupEnd') {
+                    $j--
+                }
+                if (-not $token.PSObject.Properties.Item('Depth')) {
+                    $token.PSObject.Properties.Add([Pester.Factory]::CreateNoteProperty("Depth", $j))
+                }
+                $token
+
+                $i++
+            } until ($j -eq 0 -or $i -ge $tokens.Count)
+        }
+
+        $errors = $null
+        $tokens = [System.Management.Automation.PSParser]::Tokenize($Command.Definition, [Ref]$errors)
+
+        # Find param block
+        $start = $tokens.IndexOf(($tokens | & Where-Object { $_.Content -eq 'param' } | & Select-Object -First 1)) + 1
+        $paramBlock = Get-TokenGroup $tokens[$start..($tokens.Count - 1)]
+
+        for ($i = 0; $i -lt $paramBlock.Count; $i++) {
+            $token = $paramBlock[$i]
+
+            if ($token.Depth -eq 1 -and $token.Type -eq 'Variable') {
+                $paramInfo = & New-Object PSObject -Property @{
+                    Name = $token.Content
+                } | & Select-Object Name, Type, DefaultValue, DefaultValueType
+
+                if ($paramBlock[$i + 1].Content -ne ',') {
+                    $value = $paramBlock[$i + 2]
+                    if ($value.Type -eq 'GroupStart') {
+                        $tokenGroup = Get-TokenGroup $paramBlock[($i + 2)..($paramBlock.Count - 1)]
+                        $paramInfo.DefaultValue = [String]::Join('', ($tokenGroup | & ForEach-Object { $_.Content }))
+                        $paramInfo.DefaultValueType = 'Expression'
+                    }
+                    else {
+                        $paramInfo.DefaultValue = $value.Content
+                        $paramInfo.DefaultValueType = $value.Type
+                    }
+                }
+                if ($paramBlock[$i - 1].Type -eq 'Type') {
+                    $paramInfo.Type = $paramBlock[$i - 1].Content
+                }
+                $paramInfo
+            }
+        }
+    }
+
+    function Get-ArgumentCompleter {
+        <#
+        .SYNOPSIS
+            Get custom argument completers registered in the current session.
+        .DESCRIPTION
+            Get custom argument completers registered in the current session.
+
+            By default Get-ArgumentCompleter lists all of the completers registered in the session.
+        .EXAMPLE
+            Get-ArgumentCompleter
+
+            Get all of the argument completers for PowerShell commands in the current session.
+        .EXAMPLE
+            Get-ArgumentCompleter -CommandName Invoke-ScriptAnalyzer
+
+            Get all of the argument completers used by the Invoke-ScriptAnalyzer command.
+        .EXAMPLE
+            Get-ArgumentCompleter -Native
+
+            Get all of the argument completers for native commands in the current session.
+        .NOTES
+            Author: Chris Dent
+        #>
+        [CmdletBinding()]
+        param (
+            # Filter results by command name.
+            [Parameter(Mandatory = $true)]
+            [String]$CommandName,
+
+            # Filter results by parameter name.
+            [Parameter(Mandatory = $true)]
+            [String]$ParameterName
+        )
+
+        $getExecutionContextFromTLS = [PowerShell].Assembly.GetType('System.Management.Automation.Runspaces.LocalPipeline').GetMethod(
+            'GetExecutionContextFromTLS',
+            [System.Reflection.BindingFlags]'Static, NonPublic'
+        )
+        $internalExecutionContext = $getExecutionContextFromTLS.Invoke(
+            $null,
+            [System.Reflection.BindingFlags]'Static, NonPublic',
+            $null,
+            $null,
+            $PSCulture
+        )
+
+        $argumentCompletersProperty = $internalExecutionContext.GetType().GetProperty(
+            'CustomArgumentCompleters',
+            [System.Reflection.BindingFlags]'NonPublic, Instance'
+        )
+        $argumentCompleters = $argumentCompletersProperty.GetGetMethod($true).Invoke(
+            $internalExecutionContext,
+            [System.Reflection.BindingFlags]'Instance, NonPublic, GetProperty',
+            $null,
+            @(),
+            $PSCulture
+        )
+
+        $completerName = '{0}:{1}' -f $CommandName, $ParameterName
+        if ($argumentCompleters.ContainsKey($completerName)) {
+            [PSCustomObject]@{
+                CommandName   = $CommandName
+                ParameterName = $ParameterName
+                Definition    = $argumentCompleters[$completerName]
+            }
+        }
+    }
+
+    if ($Type -is [string]) {
+        # parses type that is provided as a string in brackets (such as [int])
+        $parsedType = ($Type -replace '^\[(.*)\]$', '$1') -as [Type]
+        if ($null -eq $parsedType) {
+            throw [ArgumentException]"Could not find type [$ParsedType]. Make sure that the assembly that contains that type is loaded."
+        }
+
+        $Type = $parsedType
+    }
+    #endregion HelperFunctions
+
+    $buts = @()
+    $filters = @()
+
+    $null = $ActualValue.Parameters # necessary for PSv2
+    $hasKey = $ActualValue.Parameters.PSBase.ContainsKey($ParameterName)
+    $filters += "to$(if ($Negate) {" not"}) have a parameter $ParameterName"
+
+    if (-not $Negate -and -not $hasKey) {
+        $buts += "the parameter is missing"
+    }
+    elseif ($Negate -and -not $hasKey) {
+        return & New-Object PSObject -Property @{ Succeeded = $true }
+    }
+    elseif ($Negate -and $hasKey -and -not ($Mandatory -or $Type -or $DefaultValue -or $HasArgumentCompleter)) {
+        $buts += "the parameter exists"
+    }
+    else {
+        $attributes = $ActualValue.Parameters[$ParameterName].Attributes
+
+        #region STRICTER -Mandatory:$false check
+        if (-not $Mandatory -and $PSBoundParameters.Keys -contains "Mandatory") {
+            $testMandatory = $attributes | & Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $filters += "which is$(if (-not $Negate) {" not"}) mandatory"
+
+            if ($Negate -and -not $testMandatory) {
+                $buts += "it wasn't mandatory"
+            }
+            elseif (-not $Negate -and $testMandatory) {
+                $buts += "it was mandatory"
+            }
+        }
+        #endregion
+
+        if ($Mandatory) {
+            $testMandatory = $attributes | & Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] -and $_.Mandatory }
+            $filters += "which is$(if ($Negate) {" not"}) mandatory"
+
+            if (-not $Negate -and -not $testMandatory) {
+                $buts += "it wasn't mandatory"
+            }
+            elseif ($Negate -and $testMandatory) {
+                $buts += "it was mandatory"
+            }
+        }
+
+        if ($Type) {
+            # This block is not using `Format-Nicely`, as in PSv2 the output differs. Eg:
+            # PS2> [System.DateTime]
+            # PS5> [datetime]
+            [type]$actualType = $ActualValue.Parameters[$ParameterName].ParameterType
+            $testType = ($Type -eq $actualType)
+            $filters += "$(if ($Negate) { "not " })of type [$($Type.FullName)]"
+
+            if (-not $Negate -and -not $testType) {
+                $buts += "it was of type [$($actualType.FullName)]"
+            }
+            elseif ($Negate -and $testType) {
+                $buts += "it was of type [$($Type.FullName)]"
+            }
+        }
+
+        if ($PSBoundParameters.Keys -contains "DefaultValue") {
+            $parameterMetadata = Get-ParameterInfo $ActualValue | & Where-Object { $_.Name -eq $ParameterName }
+            $actualDefault = if ($parameterMetadata.DefaultValue) { $parameterMetadata.DefaultValue } else { "" }
+            $testDefault = ($actualDefault -eq $DefaultValue)
+            $filters += "the default value$(if ($Negate) {" not"}) to be $(Format-Nicely $DefaultValue)"
+
+            if (-not $Negate -and -not $testDefault) {
+                $buts += "the default value was $(Format-Nicely $actualDefault)"
+            }
+            elseif ($Negate -and $testDefault) {
+                $buts += "the default value was $(Format-Nicely $DefaultValue)"
+            }
+        }
+
+        if ($HasArgumentCompleter) {
+            $testArgumentCompleter = $attributes | & Where-Object { $_ -is [ArgumentCompleter] }
+
+            if (-not $testArgumentCompleter) {
+                $testArgumentCompleter = Get-ArgumentCompleter -CommandName $ActualValue.Name -ParameterName $ParameterName
+            }
+            $filters += "has ArgumentCompletion"
+
+            if (-not $Negate -and -not $testArgumentCompleter) {
+                $buts += "has no ArgumentCompletion"
+            }
+            elseif ($Negate -and $testArgumentCompleter) {
+                $buts += "has ArgumentCompletion"
+            }
+        }
+
+        if ($Alias) {
+            $testPresenceOfAlias = $ActualValue.Parameters[$ParameterName].Aliases -contains $Alias
+            $filters += "to$(if ($Negate) {" not"}) have an alias '$Alias'"
+
+            if (-not $Negate -and -not $testPresenceOfAlias) {
+                $buts += "it didn't have an alias '$Alias'"
+            }
+            elseif ($Negate -and $testPresenceOfAlias) {
+                $buts += "it had an alias '$Alias'"
+            }
+        }
+    }
+
+    if ($buts.Count -ne 0) {
+        $filter = Add-SpaceToNonEmptyString ( Join-And $filters -Threshold 3 )
+        $but = Join-And $buts
+        $failureMessage = "Expected command $($ActualValue.Name)$filter,$(Format-Because $Because) but $but."
+
+        return & New-Object PSObject -Property @{
+            Succeeded      = $false
+            FailureMessage = $failureMessage
+        }
+    }
+    else {
+        return & New-Object PSObject -Property @{ Succeeded = $true }
+    }
+}
+
+Add-ShouldOperator -Name HaveParameterStrict `
+    -InternalName Should-HaveParameterStrict `
+    -Test         ${function:Should-HaveParameterStrict}

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -141,32 +141,13 @@ Describe 'Creating connection variable' {
 
 
 Describe 'Verifying parameters' {
-    It 'Should have parameter Username' {
-        (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'Username'
-    }
-    It 'Username should be required' {
-        (Get-Command Connect-ADOPS).Parameters['Username'].Attributes.Mandatory | Should -Be $true
-    }
-
-    It 'Should have parameter PersonalAccessToken' {
-        (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'PersonalAccessToken'
-    }
-    It 'PersonalAccessToken should be required' {
-        (Get-Command Connect-ADOPS).Parameters['PersonalAccessToken'].Attributes.Mandatory | Should -Be $true
-    }
-
-    It 'Should have parameter Organization' {
-        (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'Organization'
-    }
-    It 'Organization should be required' {
-        (Get-Command Connect-ADOPS).Parameters['Organization'].Attributes.Mandatory | Should -Be $true
-    }
-
-    It 'Should have parameter Default' {
-        (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'Default'
-    }
-    It 'Default should be switch' {
-        (Get-Command Connect-ADOPS).Parameters['Default'].SwitchParameter | Should -Be $true
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Username'; Mandatory = $true }
+        @{ Name = 'PersonalAccessToken'; Mandatory = $true }
+        @{ Name = 'Organization'; Mandatory = $true }
+        @{ Name = 'Default'; Type = [switch] }
+    ) {
+        Get-Command -Name Connect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 }
 

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 BeforeAll {
     InModuleScope -ModuleName 'ADOPS' {
@@ -139,10 +141,6 @@ Describe 'Creating connection variable' {
 
 
 Describe 'Verifying parameters' {
-    BeforeAll {
-        Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-        Import-Module $PSScriptRoot\..\Source\ADOPS -Force
-    }
     It 'Should have parameter Username' {
         (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'Username'
     }

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Connect-ADOPS' {
         @{ Name = 'Organization'; Mandatory = $true }
         @{ Name = 'Default'; Type = [switch] }
     ) {
-        Get-Command -Name Connect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Connect-ADOPS | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Initial connection, No previous connection created' {

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -1,5 +1,3 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.3.1' }
-
 Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
 Import-Module $PSScriptRoot\..\Source\ADOPS -Force
 
@@ -120,7 +118,7 @@ Describe 'Creating connection variable' {
         It 'Should add this connection to connection list' {
             InModuleScope -ModuleName 'ADOPS' -Parameters @{'DummyOrg' = $DummyOrg} {
                 $script:ADOPSCredentials.Keys | Should -Contain $DummyOrg
-            
+
             }
         }
         It 'Should have only have one default conenction' {
@@ -151,21 +149,21 @@ Describe 'Verifying parameters' {
     It 'Username should be required' {
         (Get-Command Connect-ADOPS).Parameters['Username'].Attributes.Mandatory | Should -Be $true
     }
-    
+
     It 'Should have parameter PersonalAccessToken' {
         (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'PersonalAccessToken'
     }
     It 'PersonalAccessToken should be required' {
         (Get-Command Connect-ADOPS).Parameters['PersonalAccessToken'].Attributes.Mandatory | Should -Be $true
     }
-    
+
     It 'Should have parameter Organization' {
         (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'Organization'
     }
     It 'Organization should be required' {
         (Get-Command Connect-ADOPS).Parameters['Organization'].Attributes.Mandatory | Should -Be $true
     }
-    
+
     It 'Should have parameter Default' {
         (Get-Command Connect-ADOPS).Parameters.Keys | Should -Contain 'Default'
     }
@@ -180,11 +178,11 @@ Describe 'Bugfixes' {
             # One of the variable checks lacked the script: prefix
             # If you had the same variable name set in console it errored out with "Cannot index into a null array."
             Mock -CommandName InvokeADOPSRestMethod -MockWith {} -ModuleName ADOPS
-            $global:ADOPSCredentials = @{ MyOrg = 'Variable' }  
-            
+            $global:ADOPSCredentials = @{ MyOrg = 'Variable' }
+
             {Connect-ADOPS -Username 'DummyUser1' -PersonalAccessToken 'MyPatGoesHere' -Organization 'MyOrg'} | Should -Not -Throw
         }
-        AfterAll {  
+        AfterAll {
             Remove-Variable -Name ADOPSCredentials -Scope Global
         }
     }
@@ -194,7 +192,7 @@ Describe 'Validating try catch.' {
     Context 'Connect-ADOPS' {
         it 'Should trow if InvokeADOPSRestMethod returns error.' {
             Mock -CommandName InvokeADOPSRestMethod -MockWith {return throw} -ModuleName ADOPS
-            
+
             {Connect-ADOPS -Username 'DummyUser1' -PersonalAccessToken 'MyPatGoesHere' -Organization 'MyOrg'} | Should -Throw
         }
     }

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -9,7 +9,16 @@ BeforeAll {
     }
 }
 
-Describe 'Creating connection variable' {
+Describe 'Connect-ADOPS' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Username'; Mandatory = $true }
+        @{ Name = 'PersonalAccessToken'; Mandatory = $true }
+        @{ Name = 'Organization'; Mandatory = $true }
+        @{ Name = 'Default'; Type = [switch] }
+    ) {
+        Get-Command -Name Connect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
+
     Context 'Initial connection, No previous connection created' {
         BeforeAll {
             $DummyUser = 'DummyUserName'
@@ -137,17 +146,11 @@ Describe 'Creating connection variable' {
             }
         }
     }
-}
 
+    It 'Should throw if InvokeADOPSRestMethod returns error' {
+        Mock -CommandName InvokeADOPSRestMethod -MockWith {return throw} -ModuleName ADOPS
 
-Describe 'Verifying parameters' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Username'; Mandatory = $true }
-        @{ Name = 'PersonalAccessToken'; Mandatory = $true }
-        @{ Name = 'Organization'; Mandatory = $true }
-        @{ Name = 'Default'; Type = [switch] }
-    ) {
-        Get-Command -Name Connect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        {Connect-ADOPS -Username 'DummyUser1' -PersonalAccessToken 'MyPatGoesHere' -Organization 'MyOrg'} | Should -Throw
     }
 }
 
@@ -163,16 +166,6 @@ Describe 'Bugfixes' {
         }
         AfterAll {
             Remove-Variable -Name ADOPSCredentials -Scope Global
-        }
-    }
-}
-
-Describe 'Validating try catch.' {
-    Context 'Connect-ADOPS' {
-        it 'Should trow if InvokeADOPSRestMethod returns error.' {
-            Mock -CommandName InvokeADOPSRestMethod -MockWith {return throw} -ModuleName ADOPS
-
-            {Connect-ADOPS -Username 'DummyUser1' -PersonalAccessToken 'MyPatGoesHere' -Organization 'MyOrg'} | Should -Throw
         }
     }
 }

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -10,13 +10,15 @@ BeforeAll {
 }
 
 Describe 'Connect-ADOPS' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Username'; Mandatory = $true }
-        @{ Name = 'PersonalAccessToken'; Mandatory = $true }
-        @{ Name = 'Organization'; Mandatory = $true }
-        @{ Name = 'Default'; Type = [switch] }
-    ) {
-        Get-Command -Name Connect-ADOPS | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Username'; Mandatory = $true }
+            @{ Name = 'PersonalAccessToken'; Mandatory = $true }
+            @{ Name = 'Organization'; Mandatory = $true }
+            @{ Name = 'Default'; Type = [switch] }
+        ) {
+            Get-Command -Name Connect-ADOPS | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context 'Initial connection, No previous connection created' {

--- a/Tests/Disconnect-ADOPS.tests.ps1
+++ b/Tests/Disconnect-ADOPS.tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Disconnect-ADOPS tests' {
     InModuleScope -ModuleName 'ADOPS' {
@@ -80,11 +82,6 @@ Describe 'Disconnect-ADOPS tests' {
     }
 
     Context 'Verifying parameters' {
-        BeforeAll {
-            Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-            Import-Module $PSScriptRoot\..\Source\ADOPS -Force
-        }
-
         It 'Should have the parameter Organization' {
             (Get-Command Disconnect-ADOPS).Parameters.Keys | Should -Contain 'Organization'
         }

--- a/Tests/Disconnect-ADOPS.tests.ps1
+++ b/Tests/Disconnect-ADOPS.tests.ps1
@@ -1,5 +1,3 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.3.1' }
-
 Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
 Import-Module $PSScriptRoot\..\Source\ADOPS -Force
 
@@ -86,7 +84,7 @@ Describe 'Disconnect-ADOPS tests' {
             Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
             Import-Module $PSScriptRoot\..\Source\ADOPS -Force
         }
-        
+
         It 'Should have the parameter Organization' {
             (Get-Command Disconnect-ADOPS).Parameters.Keys | Should -Contain 'Organization'
         }

--- a/Tests/Disconnect-ADOPS.tests.ps1
+++ b/Tests/Disconnect-ADOPS.tests.ps1
@@ -82,11 +82,10 @@ Describe 'Disconnect-ADOPS tests' {
     }
 
     Context 'Verifying parameters' {
-        It 'Should have the parameter Organization' {
-            (Get-Command Disconnect-ADOPS).Parameters.Keys | Should -Contain 'Organization'
-        }
-        It 'Organization should not be mandatory' {
-            (Get-Command Disconnect-ADOPS).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Disconnect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
     }
 }

--- a/Tests/Disconnect-ADOPS.tests.ps1
+++ b/Tests/Disconnect-ADOPS.tests.ps1
@@ -4,10 +4,12 @@ BeforeDiscovery {
 }
 
 Describe 'Disconnect-ADOPS' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Disconnect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Disconnect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     InModuleScope -ModuleName 'ADOPS' {

--- a/Tests/Disconnect-ADOPS.tests.ps1
+++ b/Tests/Disconnect-ADOPS.tests.ps1
@@ -3,7 +3,13 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-Describe 'Disconnect-ADOPS tests' {
+Describe 'Disconnect-ADOPS' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Disconnect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
+
     InModuleScope -ModuleName 'ADOPS' {
         Context 'Command tests' {
             BeforeAll {
@@ -78,14 +84,6 @@ Describe 'Disconnect-ADOPS tests' {
                 { Disconnect-ADOPS } | Should -Throw
                 $Script:ADOPSCredentials.Count | Should -BeExactly 0
             }
-        }
-    }
-
-    Context 'Verifying parameters' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Organization'; }
-        ) {
-            Get-Command -Name Disconnect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
     }
 }

--- a/Tests/Get-ADOPSConnection.Tests.ps1
+++ b/Tests/Get-ADOPSConnection.Tests.ps1
@@ -4,10 +4,12 @@ BeforeDiscovery {
 }
 
 Describe 'Get-ADOPSConnection' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Get-ADOPSConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Get-ADOPSConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context 'Verifying returned values' {

--- a/Tests/Get-ADOPSConnection.Tests.ps1
+++ b/Tests/Get-ADOPSConnection.Tests.ps1
@@ -7,7 +7,7 @@ Describe 'Get-ADOPSConnection' {
     It 'Has parameter <_.Name>' -TestCases @(
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Get-ADOPSConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Verifying returned values' {

--- a/Tests/Get-ADOPSConnection.Tests.ps1
+++ b/Tests/Get-ADOPSConnection.Tests.ps1
@@ -4,10 +4,10 @@ BeforeDiscovery {
 }
 
 Describe 'Get-ADOPSConnection' {
-    Context 'Function tests' {
-        It 'We have a function' {
-            Get-Command Get-ADOPSConnection -Module ADOPS | Should -Not -BeNullOrEmpty
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Get-ADOPSConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Verifying returned values' {

--- a/Tests/Get-ADOPSConnection.Tests.ps1
+++ b/Tests/Get-ADOPSConnection.Tests.ps1
@@ -1,6 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
-
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Get-ADOPSConnection' {
     Context 'Function tests' {
@@ -24,7 +25,7 @@ Describe 'Get-ADOPSConnection' {
                 }
             }
         }
-        
+
         It 'Given we have two connections, both connections should be returned' {
             (Get-ADOPSConnection).Count | Should -Be 2
         }

--- a/Tests/Get-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Get-ADOPSElasticPool.Tests.ps1
@@ -4,14 +4,11 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSElasticPool" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name Get-ADOPSElasticPool -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'Organization', 'PoolId' {
-            (Get-Command -Name Get-ADOPSElasticPool).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'PoolId'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Get-ADOPSElasticPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns elastic pools" {

--- a/Tests/Get-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Get-ADOPSElasticPool.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Get-ADOPSElasticPool" {
         @{ Name = 'PoolId'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Get-ADOPSElasticPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns elastic pools" {

--- a/Tests/Get-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Get-ADOPSElasticPool.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "Get-ADOPSElasticPool" {
     Context "Function tests" {
@@ -118,7 +120,7 @@ Describe "Get-ADOPSElasticPool" {
                     timeToLiveMinutes    = 15
                 }
             }
-            
+
             (Get-ADOPSElasticPool -Organization 'DummyOrg' -PoolId 10).poolId | Should -Be 10
         }
     }

--- a/Tests/Get-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Get-ADOPSElasticPool.Tests.ps1
@@ -4,11 +4,13 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSElasticPool" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'PoolId'; }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Get-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'PoolId'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Get-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns elastic pools" {

--- a/Tests/Get-ADOPSNode.Tests.ps1
+++ b/Tests/Get-ADOPSNode.Tests.ps1
@@ -5,7 +5,7 @@ BeforeDiscovery {
 
 Describe "Get-ADOPSNode" {
     It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'PoolId'; }
+        @{ Name = 'PoolId'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
         Get-Command -Name Get-ADOPSNode| Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type

--- a/Tests/Get-ADOPSNode.Tests.ps1
+++ b/Tests/Get-ADOPSNode.Tests.ps1
@@ -4,14 +4,11 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSNode" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name Get-ADOPSNode -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'Organization', 'PoolId' {
-            (Get-Command -Name Get-ADOPSNode).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'PoolId'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Get-ADOPSNode| Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns repositories" {

--- a/Tests/Get-ADOPSNode.Tests.ps1
+++ b/Tests/Get-ADOPSNode.Tests.ps1
@@ -4,11 +4,13 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSNode" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'PoolId'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Get-ADOPSNode| Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'PoolId'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Get-ADOPSNode | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns repositories" {

--- a/Tests/Get-ADOPSNode.Tests.ps1
+++ b/Tests/Get-ADOPSNode.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Get-ADOPSNode" {
         @{ Name = 'PoolId'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Get-ADOPSNode| Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSNode| Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns repositories" {

--- a/Tests/Get-ADOPSNode.Tests.ps1
+++ b/Tests/Get-ADOPSNode.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "Get-ADOPSNode" {
     Context "Function tests" {
@@ -28,7 +30,7 @@ Describe "Get-ADOPSNode" {
                             agentState     = @('enabled', 'online')
                             computeId      = 0
                             computeState   = 'healthy'
-                            requestId      = ''                    
+                            requestId      = ''
                         },
                         @{
                             poolId         = 10
@@ -41,7 +43,7 @@ Describe "Get-ADOPSNode" {
                             agentState     = @('enabled', 'online')
                             computeId      = 1
                             computeState   = 'healthy'
-                            requestId      = ''                    
+                            requestId      = ''
                         }
                     )
                 }
@@ -99,10 +101,10 @@ Describe "Get-ADOPSNode" {
                     agentState     = @('enabled', 'online')
                     computeId      = 0
                     computeState   = 'healthy'
-                    requestId      = ''                    
+                    requestId      = ''
                 }
             }
-            
+
             (Get-ADOPSNode -Organization 'DummyOrg' -PoolId 10).name | Should -Be 'vmss-test000000'
         }
     }

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Get-ADOPSPipeline tests' {
@@ -9,7 +11,7 @@ InModuleScope -ModuleName ADOPS {
                 $OrganizationName = 'DummyOrg'
                 $Project = 'DummyProject'
                 $PipeName = 'DummyPipe1'
-                
+
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
                     @{
                         Header       = @{

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Get-ADOPSPipeline tests' {
         @{ Name = 'Project'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Get-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
     Context 'Getting Pipeline' {
         BeforeAll {

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -4,13 +4,16 @@ BeforeDiscovery {
 }
 
 Describe 'Get-ADOPSPipeline tests' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Name'; }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Get-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Get-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
+
     Context 'Getting Pipeline' {
         BeforeAll {
 

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -5,6 +5,13 @@ BeforeDiscovery {
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Get-ADOPSPipeline tests' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Get-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
         Context 'Getting Pipeline' {
             BeforeAll {
 
@@ -103,27 +110,6 @@ InModuleScope -ModuleName ADOPS {
             }
             It 'returns multiple outputs after getting pipelines' {
                 (Get-ADOPSPipeline -Organization $OrganizationName -Project $Project).count | Should -Be 2
-            }
-        }
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command Get-ADOPSPipeline).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Organization should not be required' {
-                (Get-Command Get-ADOPSPipeline).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Project' {
-                (Get-Command Get-ADOPSPipeline).Parameters.Keys | Should -Contain 'Project'
-            }
-            It 'Project should be required' {
-                (Get-Command Get-ADOPSPipeline).Parameters['Project'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter Name' {
-                (Get-Command Get-ADOPSPipeline).Parameters.Keys | Should -Contain 'Name'
-            }
-            It 'Name should not be required' {
-                (Get-Command Get-ADOPSPipeline).Parameters['Name'].Attributes.Mandatory | Should -Be $false
             }
         }
     }

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -3,114 +3,112 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-InModuleScope -ModuleName ADOPS {
-    Describe 'Get-ADOPSPipeline tests' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Name'; }
-            @{ Name = 'Project'; Mandatory = $true }
-            @{ Name = 'Organization'; }
-        ) {
-            Get-Command -Name Get-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
-        }
-        Context 'Getting Pipeline' {
-            BeforeAll {
+Describe 'Get-ADOPSPipeline tests' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Name'; }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Get-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
+    Context 'Getting Pipeline' {
+        BeforeAll {
 
-                $OrganizationName = 'DummyOrg'
-                $Project = 'DummyProject'
-                $PipeName = 'DummyPipe1'
+            $OrganizationName = 'DummyOrg'
+            $Project = 'DummyProject'
+            $PipeName = 'DummyPipe1'
 
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
                     }
-                } -ParameterFilter { $OrganizationName -eq $OrganizationName }
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
-                    }
+                    Organization = $OrganizationName
                 }
-
-                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    return @'
-                    {
-                        "value": [
-                            {
-                                "_links": {
-                                "self": "@{href=https://dev.azure.com/OrganizationName/Project/_apis/pipelines/10?revision=1}",
-                                "web": "@{href=https://dev.azure.com/OrganizationName/Project/_build/definition?definitionId=10}"
-                                },
-                                "url": "https://dev.azure.com/OrganizationName/Project/_apis/pipelines/10?revision=1",
-                                "id": 10,
-                                "revision": 1,
-                                "name": "DummyPipe1",
-                                "folder": "\\"
-                            },
-                            {
-                                "_links": {
-                                "self": "@{href=https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1}",
-                                "web": "@{href=https://dev.azure.com/OrganizationName/Project/_build/definition?definitionId=9}"
-                                },
-                                "url": "https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1",
-                                "id": 9,
-                                "revision": 1,
-                                "name": "DummyPipe2",
-                                "folder": "\\"
-                            }
-                        ]
+            } -ParameterFilter { $OrganizationName -eq $OrganizationName }
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
                     }
-'@ | ConvertFrom-Json
-                } -ParameterFilter { $Method -eq 'Get' -and $Uri -like '*/pipelines?*' }
+                    Organization = $OrganizationName
+                }
+            }
 
-                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    return @'
-                    {
-                        "_links": {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return @'
+                {
+                    "value": [
+                        {
+                            "_links": {
+                            "self": "@{href=https://dev.azure.com/OrganizationName/Project/_apis/pipelines/10?revision=1}",
+                            "web": "@{href=https://dev.azure.com/OrganizationName/Project/_build/definition?definitionId=10}"
+                            },
+                            "url": "https://dev.azure.com/OrganizationName/Project/_apis/pipelines/10?revision=1",
+                            "id": 10,
+                            "revision": 1,
+                            "name": "DummyPipe1",
+                            "folder": "\\"
+                        },
+                        {
+                            "_links": {
                             "self": "@{href=https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1}",
                             "web": "@{href=https://dev.azure.com/OrganizationName/Project/_build/definition?definitionId=9}"
-                        },
-                        "configuration": {
-                            "path": "DummyPipe1Path.yml",
-                            "repository": "@{id=Repo; type=azureReposGit}",
-                            "type": "yaml"
-                        },
-                        "url": "https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1",
-                        "id": 9,
-                        "revision": 1,
-                        "name": "DummyPipe1",
-                        "folder": "\\"
-                    }
+                            },
+                            "url": "https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1",
+                            "id": 9,
+                            "revision": 1,
+                            "name": "DummyPipe2",
+                            "folder": "\\"
+                        }
+                    ]
+                }
 '@ | ConvertFrom-Json
-                } -ParameterFilter { $Method -eq 'Get' -and $Uri -like '*/pipelines/*' }
+            } -ParameterFilter { $Method -eq 'Get' -and $Uri -like '*/pipelines?*' }
 
-            }
-            It 'uses InvokeADOPSRestMethod two times' {
-                Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName
-                Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 2
-            }
-            It 'returns output after getting pipeline' {
-                Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
-            }
-            It 'should not throw with mandatory parameters' {
-                { Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName } | Should -Not -Throw
-            }
-            It 'should not throw without Organization parameter' {
-                { Get-ADOPSPipeline -Project $Project -Name $PipeName } | Should -Not -Throw
-            }
-            It 'should throw if pipeline name does not exist' {
-                { Get-ADOPSPipeline -Project $Project -Name 'MissingPipeline' } | Should -Throw
-            }
-            It 'returns single output after getting pipeline' {
-                (Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName).count | Should -Be 1
-            }
-            It 'returns multiple outputs after getting pipelines' {
-                (Get-ADOPSPipeline -Organization $OrganizationName -Project $Project).count | Should -Be 2
-            }
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return @'
+                {
+                    "_links": {
+                        "self": "@{href=https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1}",
+                        "web": "@{href=https://dev.azure.com/OrganizationName/Project/_build/definition?definitionId=9}"
+                    },
+                    "configuration": {
+                        "path": "DummyPipe1Path.yml",
+                        "repository": "@{id=Repo; type=azureReposGit}",
+                        "type": "yaml"
+                    },
+                    "url": "https://dev.azure.com/OrganizationName/Project/_apis/pipelines/9?revision=1",
+                    "id": 9,
+                    "revision": 1,
+                    "name": "DummyPipe1",
+                    "folder": "\\"
+                }
+'@ | ConvertFrom-Json
+            } -ParameterFilter { $Method -eq 'Get' -and $Uri -like '*/pipelines/*' }
+
+        }
+        It 'uses InvokeADOPSRestMethod two times' {
+            Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 2
+        }
+        It 'returns output after getting pipeline' {
+            Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
+        }
+        It 'should not throw with mandatory parameters' {
+            { Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName } | Should -Not -Throw
+        }
+        It 'should not throw without Organization parameter' {
+            { Get-ADOPSPipeline -Project $Project -Name $PipeName } | Should -Not -Throw
+        }
+        It 'should throw if pipeline name does not exist' {
+            { Get-ADOPSPipeline -Project $Project -Name 'MissingPipeline' } | Should -Throw
+        }
+        It 'returns single output after getting pipeline' {
+            (Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName).count | Should -Be 1
+        }
+        It 'returns multiple outputs after getting pipelines' {
+            (Get-ADOPSPipeline -Organization $OrganizationName -Project $Project).count | Should -Be 2
         }
     }
 }

--- a/Tests/Get-ADOPSPool.Tests.ps1
+++ b/Tests/Get-ADOPSPool.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "Get-ADOPSPool" {
     Context "Function tests" {
@@ -132,7 +134,7 @@ Describe "Get-ADOPSPool" {
                     options       = 'none'
                 }
             }
-            
+
             (Get-ADOPSPool -Organization 'DummyOrg' -PoolId 8).name | Should -Be 'Hosted Ubuntu 1604'
         }
     }

--- a/Tests/Get-ADOPSPool.Tests.ps1
+++ b/Tests/Get-ADOPSPool.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Get-ADOPSPool" {
         @{ Name = 'IncludeLegacy' }
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name Get-ADOPSPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns agent pools" {

--- a/Tests/Get-ADOPSPool.Tests.ps1
+++ b/Tests/Get-ADOPSPool.Tests.ps1
@@ -4,15 +4,16 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSPool" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'PoolId'; Mandatory = $true }
-        @{ Name = 'PoolName'; Mandatory = $true }
-        @{ Name = 'IncludeLegacy' }
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name Get-ADOPSPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'PoolId'; Mandatory = $true }
+            @{ Name = 'PoolName'; Mandatory = $true }
+            @{ Name = 'IncludeLegacy' }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
-
     Context "Function returns agent pools" {
         BeforeAll {
             Mock InvokeADOPSRestMethod -ModuleName ADOPS {

--- a/Tests/Get-ADOPSPool.Tests.ps1
+++ b/Tests/Get-ADOPSPool.Tests.ps1
@@ -4,14 +4,13 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSPool" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name Get-ADOPSPool -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'Organization', 'PoolId', 'PoolName', 'IncludeLegacy' {
-            (Get-Command -Name Get-ADOPSPool).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'PoolId'; Mandatory = $true }
+        @{ Name = 'PoolName'; Mandatory = $true }
+        @{ Name = 'IncludeLegacy' }
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name Get-ADOPSPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns agent pools" {

--- a/Tests/Get-ADOPSProject.Tests.ps1
+++ b/Tests/Get-ADOPSProject.Tests.ps1
@@ -5,6 +5,13 @@ BeforeDiscovery {
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Get-ADOPSProject tests' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Project' }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSProject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
+
         Context 'Get project' {
             BeforeAll {
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
@@ -55,21 +62,6 @@ InModuleScope -ModuleName ADOPS {
             }
             It 'should not throw with no parameters' {
                 { Get-ADOPSProject } | Should -Not -Throw
-            }
-        }
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command Get-ADOPSProject).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Organization should not be required' {
-                (Get-Command Get-ADOPSProject).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Project' {
-                (Get-Command Get-ADOPSProject).Parameters.Keys | Should -Contain 'Project'
-            }
-            It 'Project not should be required' {
-                (Get-Command Get-ADOPSProject).Parameters['Project'].Attributes.Mandatory | Should -Be $false
             }
         }
     }

--- a/Tests/Get-ADOPSProject.Tests.ps1
+++ b/Tests/Get-ADOPSProject.Tests.ps1
@@ -3,36 +3,35 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-InModuleScope -ModuleName ADOPS {
-    Describe 'Get-ADOPSProject tests' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Project' }
-            @{ Name = 'Organization' }
-        ) {
-            Get-Command -Name Get-ADOPSProject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
-        }
+Describe 'Get-ADOPSProject tests' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Project' }
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name Get-ADOPSProject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
 
-        Context 'Get project' {
-            BeforeAll {
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
+    Context 'Get project' {
+        BeforeAll {
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
                     }
-                } -ParameterFilter { $OrganizationName -eq 'Organization' }
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
-                    }
+                    Organization = $OrganizationName
                 }
+            } -ParameterFilter { $OrganizationName -eq 'Organization' }
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
+                    }
+                    Organization = $OrganizationName
+                }
+            }
 
-                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    return @'
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return @'
                     {
                         "value": [
                             {
@@ -47,22 +46,21 @@ InModuleScope -ModuleName ADOPS {
                         ]
                     }
 '@ | ConvertFrom-Json
-                } -ParameterFilter { $method -eq 'GET' }
+            } -ParameterFilter { $method -eq 'GET' }
 
-                $OrganizationName = 'DummyOrg'
-                $Project = 'DummyProject'
-            }
+            $OrganizationName = 'DummyOrg'
+            $Project = 'DummyProject'
+        }
 
-            It 'uses InvokeADOPSRestMethod one time.' {
-                Get-ADOPSProject -Organization $OrganizationName -Project $Project
-                Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
-            }
-            It 'returns output after getting project' {
-                Get-ADOPSProject -Organization $OrganizationName -Project $Project | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
-            }
-            It 'should not throw with no parameters' {
-                { Get-ADOPSProject } | Should -Not -Throw
-            }
+        It 'uses InvokeADOPSRestMethod one time.' {
+            Get-ADOPSProject -Organization $OrganizationName -Project $Project
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+        }
+        It 'returns output after getting project' {
+            Get-ADOPSProject -Organization $OrganizationName -Project $Project | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
+        }
+        It 'should not throw with no parameters' {
+            { Get-ADOPSProject } | Should -Not -Throw
         }
     }
 }

--- a/Tests/Get-ADOPSProject.Tests.ps1
+++ b/Tests/Get-ADOPSProject.Tests.ps1
@@ -4,11 +4,13 @@ BeforeDiscovery {
 }
 
 Describe 'Get-ADOPSProject tests' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Project' }
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name Get-ADOPSProject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Project' }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSProject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context 'Get project' {

--- a/Tests/Get-ADOPSProject.Tests.ps1
+++ b/Tests/Get-ADOPSProject.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Get-ADOPSProject tests' {
         @{ Name = 'Project' }
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name Get-ADOPSProject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSProject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Get project' {

--- a/Tests/Get-ADOPSProject.Tests.ps1
+++ b/Tests/Get-ADOPSProject.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Get-ADOPSProject tests' {
@@ -45,7 +47,7 @@ InModuleScope -ModuleName ADOPS {
             }
 
             It 'uses InvokeADOPSRestMethod one time.' {
-                Get-ADOPSProject -Organization $OrganizationName -Project $Project 
+                Get-ADOPSProject -Organization $OrganizationName -Project $Project
                 Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
             }
             It 'returns output after getting project' {

--- a/Tests/Get-ADOPSRepository.Tests.ps1
+++ b/Tests/Get-ADOPSRepository.Tests.ps1
@@ -4,14 +4,12 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSRepository" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name Get-ADOPSRepository -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'Organization', 'Project', 'Repository' {
-            (Get-Command -Name Get-ADOPSRepository).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Repository' }
+        @{ Name = 'Project' }
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name Get-ADOPSRepository | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns repositories" {

--- a/Tests/Get-ADOPSRepository.Tests.ps1
+++ b/Tests/Get-ADOPSRepository.Tests.ps1
@@ -4,12 +4,14 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSRepository" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Repository' }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name Get-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Repository' }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns repositories" {

--- a/Tests/Get-ADOPSRepository.Tests.ps1
+++ b/Tests/Get-ADOPSRepository.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "Get-ADOPSRepository" {
     Context "Function tests" {
@@ -67,7 +69,7 @@ Describe "Get-ADOPSRepository" {
                     Name = 'Fisar'
                 }
             }
-            
+
             (Get-ADOPSRepository -Organization 'MyOrg' -Project 'MyProject' -Repository 'MyRepo').Name | Should -Be 'Fisar'
         }
     }

--- a/Tests/Get-ADOPSRepository.Tests.ps1
+++ b/Tests/Get-ADOPSRepository.Tests.ps1
@@ -6,7 +6,7 @@ BeforeDiscovery {
 Describe "Get-ADOPSRepository" {
     It 'Has parameter <_.Name>' -TestCases @(
         @{ Name = 'Repository' }
-        @{ Name = 'Project' }
+        @{ Name = 'Project'; Mandatory = $true }
         @{ Name = 'Organization' }
     ) {
         Get-Command -Name Get-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type

--- a/Tests/Get-ADOPSRepository.Tests.ps1
+++ b/Tests/Get-ADOPSRepository.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Get-ADOPSRepository" {
         @{ Name = 'Project' }
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name Get-ADOPSRepository | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns repositories" {

--- a/Tests/Get-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Get-ADOPSServiceConnection.Tests.ps1
@@ -4,13 +4,16 @@ BeforeDiscovery {
 }
 
 Describe 'Get-ADOPSServiceConnection tests' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Name'; }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
+
     Context 'Command tests' {
         BeforeAll {
 

--- a/Tests/Get-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Get-ADOPSServiceConnection.Tests.ps1
@@ -3,41 +3,40 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-InModuleScope -ModuleName ADOPS {
-    Describe 'Get-ADOPSServiceConnection tests' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Name'; }
-            @{ Name = 'Project'; Mandatory = $true }
-            @{ Name = 'Organization' }
-        ) {
-            Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
-        }
-        Context 'Command tests' {
-            BeforeAll {
+Describe 'Get-ADOPSServiceConnection tests' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Name'; }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
+    Context 'Command tests' {
+        BeforeAll {
 
-                $OrganizationName = 'DummyOrg'
-                $Project = 'DummyProject'
-                $SCName = 'DummySC1'
+            $OrganizationName = 'DummyOrg'
+            $Project = 'DummyProject'
+            $SCName = 'DummySC1'
 
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
                     }
-                } -ParameterFilter { $OrganizationName -eq $OrganizationName }
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
-                    }
+                    Organization = $OrganizationName
                 }
+            } -ParameterFilter { $OrganizationName -eq $OrganizationName }
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
+                    }
+                    Organization = $OrganizationName
+                }
+            }
 
-                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    return @'
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return @'
                     {
                         "value": [
                             {
@@ -73,29 +72,27 @@ InModuleScope -ModuleName ADOPS {
                         ]
                     }
 '@ | ConvertFrom-Json
-                } -ParameterFilter { $Method -eq 'Get' }
+            } -ParameterFilter { $Method -eq 'Get' }
 
-            }
-            It 'uses InvokeADOPSRestMethod one time.' {
-                Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName
-                Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
-            }
-            It 'returns output after getting pipeline' {
-                Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
-            }
-            It 'should not throw without optional parameters' {
-                { Get-ADOPSServiceConnection -Project $Project } | Should -Not -Throw
-            }
-            It 'should throw if connection name does not exist' {
-                { Get-ADOPSServiceConnection -Project $Project -Name 'MissingName' } | Should -Throw
-            }
-            It 'returns single output after getting pipeline' {
+        }
+        It 'uses InvokeADOPSRestMethod one time.' {
+            Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+        }
+        It 'returns output after getting pipeline' {
+            Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'
+        }
+        It 'should not throw without optional parameters' {
+            { Get-ADOPSServiceConnection -Project $Project } | Should -Not -Throw
+        }
+        It 'should throw if connection name does not exist' {
+            { Get-ADOPSServiceConnection -Project $Project -Name 'MissingName' } | Should -Throw
+        }
+        It 'returns single output after getting pipeline' {
                 (Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName).count | Should -Be 1
-            }
-            It 'returns multiple outputs after getting pipelines' {
+        }
+        It 'returns multiple outputs after getting pipelines' {
                 (Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project).count | Should -Be 2
-            }
         }
     }
 }
-

--- a/Tests/Get-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Get-ADOPSServiceConnection.Tests.ps1
@@ -5,6 +5,13 @@ BeforeDiscovery {
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Get-ADOPSServiceConnection tests' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
         Context 'Command tests' {
             BeforeAll {
 
@@ -88,22 +95,6 @@ InModuleScope -ModuleName ADOPS {
             It 'returns multiple outputs after getting pipelines' {
                 (Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project).count | Should -Be 2
             }
-        }
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command Get-ADOPSServiceConnection).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Organization should not be required' {
-                (Get-Command Get-ADOPSServiceConnection).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Project' {
-                (Get-Command Get-ADOPSServiceConnection).Parameters.Keys | Should -Contain 'Project'
-            }
-            It 'Should have parameter Name' {
-                (Get-Command Get-ADOPSServiceConnection).Parameters.Keys | Should -Contain 'Name'
-            }
-
         }
     }
 }

--- a/Tests/Get-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Get-ADOPSServiceConnection.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Get-ADOPSServiceConnection tests' {
         @{ Name = 'Project'; Mandatory = $true }
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSServiceConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
     Context 'Command tests' {
         BeforeAll {

--- a/Tests/Get-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Get-ADOPSServiceConnection.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Get-ADOPSServiceConnection tests' {
@@ -68,7 +70,7 @@ InModuleScope -ModuleName ADOPS {
 
             }
             It 'uses InvokeADOPSRestMethod one time.' {
-                Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName  
+                Get-ADOPSServiceConnection -Organization $OrganizationName -Project $Project -Name $SCName
                 Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
             }
             It 'returns output after getting pipeline' {

--- a/Tests/Get-ADOPSUser.Tests.ps1
+++ b/Tests/Get-ADOPSUser.Tests.ps1
@@ -4,14 +4,13 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSUser" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name Get-ADOPSUser -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
 
-        It 'Has parameter <_>' -TestCases 'Organization', 'Name', 'Descriptor' {
-            (Get-Command -Name Get-ADOPSUser).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Name'; Mandatory = $true }
+        @{ Name = 'Descriptor'; Mandatory = $true }
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name Get-ADOPSUser | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns all users" {

--- a/Tests/Get-ADOPSUser.Tests.ps1
+++ b/Tests/Get-ADOPSUser.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "Get-ADOPSUser" {
     Context "Function tests" {

--- a/Tests/Get-ADOPSUser.Tests.ps1
+++ b/Tests/Get-ADOPSUser.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Get-ADOPSUser" {
         @{ Name = 'Descriptor'; Mandatory = $true }
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name Get-ADOPSUser | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSUser | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns all users" {

--- a/Tests/Get-ADOPSUser.Tests.ps1
+++ b/Tests/Get-ADOPSUser.Tests.ps1
@@ -4,13 +4,14 @@ BeforeDiscovery {
 }
 
 Describe "Get-ADOPSUser" {
-
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Name'; Mandatory = $true }
-        @{ Name = 'Descriptor'; Mandatory = $true }
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name Get-ADOPSUser | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; Mandatory = $true }
+            @{ Name = 'Descriptor'; Mandatory = $true }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSUser | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns all users" {

--- a/Tests/Get-ADOPSWiki.Tests.ps1
+++ b/Tests/Get-ADOPSWiki.Tests.ps1
@@ -19,18 +19,12 @@ Describe 'Get-ADOPSWiki' {
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
-    Context "General function tests" {
-        It "Function exist" {
-            { Get-Command -Name Get-ADOPSWiki -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It "Contains non mandatory parameter: <_>" -TestCases 'Organization', 'WikiId' {
-            Get-Command -Name Get-ADOPSWiki | Should -HaveParameter $_
-        }
-
-        It "Contains mandatory parameter: <_>" -TestCases 'Project' {
-            Get-Command -Name Get-ADOPSWiki | Should -HaveParameter $_ -Mandatory
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'WikiId'; }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name Get-ADOPSWiki | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Functionality" {

--- a/Tests/Get-ADOPSWiki.Tests.ps1
+++ b/Tests/Get-ADOPSWiki.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Get-ADOPSWiki' {
         @{ Name = 'Project'; Mandatory = $true }
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name Get-ADOPSWiki | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Get-ADOPSWiki | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Functionality" {

--- a/Tests/Get-ADOPSWiki.Tests.ps1
+++ b/Tests/Get-ADOPSWiki.Tests.ps1
@@ -19,12 +19,14 @@ Describe 'Get-ADOPSWiki' {
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'WikiId'; }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name Get-ADOPSWiki | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'WikiId'; }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name Get-ADOPSWiki | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Functionality" {

--- a/Tests/Get-ADOPSWiki.Tests.ps1
+++ b/Tests/Get-ADOPSWiki.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Get-ADOPSWiki' {
     BeforeAll {
@@ -13,7 +15,7 @@ Describe 'Get-ADOPSWiki' {
                 Organization = "anotherOrg"
             }
         }
-        
+
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
@@ -34,7 +36,7 @@ Describe 'Get-ADOPSWiki' {
     Context "Functionality" {
 
         It 'Should get organization from GetADOPSHeader when organization parameter is used' {
-            Get-ADOPSWiki -Organization 'anotherorg' -Project 'myproj' 
+            Get-ADOPSWiki -Organization 'anotherorg' -Project 'myproj'
             Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -Times 1 -Exactly
         }
 
@@ -69,7 +71,7 @@ Describe 'Get-ADOPSWiki' {
             $r = Get-ADOPSWiki -Project 'myproj'
             $r.name | Should -Be 'HasNoValue'
         }
-        
+
         It 'Verifying URI, no WikiID given' {
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
                 return $URI

--- a/Tests/GetADOPSHeader.Tests.ps1
+++ b/Tests/GetADOPSHeader.Tests.ps1
@@ -3,42 +3,40 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-InModuleScope -ModuleName ADOPS {
+Describe 'GetADOPSHeader' {
     BeforeAll {
-        $Script:ADOPSCredentials = @{
-            'org1' = @{
-                Credential = [pscredential]::new('DummyUser1',(ConvertTo-SecureString -String 'DummyPassword1' -AsPlainText -Force))
-                Default = $false
-            }
-            'org2' = @{
-                Credential = [pscredential]::new('DummyUser2',(ConvertTo-SecureString -String 'DummyPassword2' -AsPlainText -Force))
-                Default = $true
+        InModuleScope -ModuleName ADOPS {
+            $Script:ADOPSCredentials = @{
+                'org1' = @{
+                    Credential = [pscredential]::new('DummyUser1', (ConvertTo-SecureString -String 'DummyPassword1' -AsPlainText -Force))
+                    Default    = $false
+                }
+                'org2' = @{
+                    Credential = [pscredential]::new('DummyUser2', (ConvertTo-SecureString -String 'DummyPassword2' -AsPlainText -Force))
+                    Default    = $true
+                }
             }
         }
     }
-
-
-    Describe 'GetADOPSHeader' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Organization' }
-        ) {
-            Get-Command -Name GetADOPSHeader | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Organization' }
+    ) {
+        Get-Command -Name GetADOPSHeader | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
+    Context 'Given no input, should return the default connection' {
+        It 'Should return credential value of default organization, org2' {
+            (GetADOPSHeader).Header.Authorization | Should -BeLike "basic*"
         }
-        Context 'Given no input, should return the default connection' {
-            It 'Should return credential value of default organization, org2' {
-                (GetADOPSHeader).Header.Authorization | Should -BeLike "basic*"
-            }
-            It 'Token should contain organization name' {
-                (GetADOPSHeader).Organization | Should -Be 'org2'
-            }
+        It 'Token should contain organization name' {
+            (GetADOPSHeader).Organization | Should -Be 'org2'
         }
-        Context 'Given an organization as input, should return that organization' {
-            It 'Should return credential value of default organization, org1' {
-                (GetADOPSHeader -Organization 'org1').Header.Authorization | Should -BeLike "basic*"
-            }
-            It 'Token should contain organization name' {
-                (GetADOPSHeader -Organization 'org1').Organization | Should -Be 'org1'
-            }
+    }
+    Context 'Given an organization as input, should return that organization' {
+        It 'Should return credential value of default organization, org1' {
+            (GetADOPSHeader -Organization 'org1').Header.Authorization | Should -BeLike "basic*"
+        }
+        It 'Token should contain organization name' {
+            (GetADOPSHeader -Organization 'org1').Organization | Should -Be 'org1'
         }
     }
 }

--- a/Tests/GetADOPSHeader.Tests.ps1
+++ b/Tests/GetADOPSHeader.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     BeforeAll {
@@ -15,7 +17,7 @@ InModuleScope -ModuleName ADOPS {
         }
     }
 
-    
+
     Describe 'GetADOPSHeader' {
         Context 'Given no input, should return the default connection' {
             It 'Should return credential value of default organization, org2' {
@@ -37,10 +39,6 @@ InModuleScope -ModuleName ADOPS {
 }
 
 Describe 'Verifying parameters' {
-    BeforeAll {
-        Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-        Import-Module $PSScriptRoot\..\Source\ADOPS -Force
-    }
     It 'Should have parameter Organization' {
         InModuleScope -ModuleName 'ADOPS' {
             (Get-Command GetADOPSHeader).Parameters.Keys | Should -Contain 'Organization'

--- a/Tests/GetADOPSHeader.Tests.ps1
+++ b/Tests/GetADOPSHeader.Tests.ps1
@@ -21,7 +21,7 @@ Describe 'GetADOPSHeader' {
     It 'Has parameter <_.Name>' -TestCases @(
         @{ Name = 'Organization' }
     ) {
-        Get-Command -Name GetADOPSHeader | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name GetADOPSHeader | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
     Context 'Given no input, should return the default connection' {
         It 'Should return credential value of default organization, org2' {

--- a/Tests/GetADOPSHeader.Tests.ps1
+++ b/Tests/GetADOPSHeader.Tests.ps1
@@ -18,10 +18,12 @@ Describe 'GetADOPSHeader' {
             }
         }
     }
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Organization' }
-    ) {
-        Get-Command -Name GetADOPSHeader | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name GetADOPSHeader | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
     Context 'Given no input, should return the default connection' {
         It 'Should return credential value of default organization, org2' {

--- a/Tests/GetADOPSHeader.Tests.ps1
+++ b/Tests/GetADOPSHeader.Tests.ps1
@@ -19,6 +19,11 @@ InModuleScope -ModuleName ADOPS {
 
 
     Describe 'GetADOPSHeader' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Organization' }
+        ) {
+            Get-Command -Name GetADOPSHeader | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
         Context 'Given no input, should return the default connection' {
             It 'Should return credential value of default organization, org2' {
                 (GetADOPSHeader).Header.Authorization | Should -BeLike "basic*"
@@ -34,14 +39,6 @@ InModuleScope -ModuleName ADOPS {
             It 'Token should contain organization name' {
                 (GetADOPSHeader -Organization 'org1').Organization | Should -Be 'org1'
             }
-        }
-    }
-}
-
-Describe 'Verifying parameters' {
-    It 'Should have parameter Organization' {
-        InModuleScope -ModuleName 'ADOPS' {
-            (Get-Command GetADOPSHeader).Parameters.Keys | Should -Contain 'Organization'
         }
     }
 }

--- a/Tests/Import-ADOPSRepository.Tests.ps1
+++ b/Tests/Import-ADOPSRepository.Tests.ps1
@@ -4,7 +4,7 @@ BeforeDiscovery {
 }
 
 Describe 'Import-ADOPSRepository' {
-    Context 'Command structure' {
+    Context 'Parameter validation' {
         BeforeAll {
             $command  = Get-Command -Name Import-ADOPSRepository -Module ADOPS
         }

--- a/Tests/Import-ADOPSRepository.Tests.ps1
+++ b/Tests/Import-ADOPSRepository.Tests.ps1
@@ -15,7 +15,7 @@ Describe 'Import-ADOPSRepository' {
             @{ Name = 'Project'; Mandatory = $true }
             @{ Name = 'Organization'; }
         ) {
-            $command | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            $command | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
         It 'GitSource parameter should be in all parametersets: <_>' -TestCases $command.ParameterSets.Name {
             $command.Parameters['GitSource'].ParameterSets.Keys | Should -Contain $_

--- a/Tests/Import-ADOPSRepository.Tests.ps1
+++ b/Tests/Import-ADOPSRepository.Tests.ps1
@@ -6,31 +6,34 @@ BeforeDiscovery {
 Describe 'Import-ADOPSRepository' {
     Context 'Command structure' {
         BeforeAll {
-            $r  = Get-Command -Name Import-ADOPSRepository -Module ADOPS
+            $command  = Get-Command -Name Import-ADOPSRepository -Module ADOPS
         }
-        It 'Command should exist' {
-            $r | Should -Not -BeNullOrEmpty
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'GitSource'; Mandatory = $true }
+            @{ Name = 'RepositoryId'; Mandatory = $true }
+            @{ Name = 'RepositoryName'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            $command | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
-        It 'Has parameter <_>' -TestCases 'GitSource', 'RepositoryId', 'RepositoryName', 'Organization', 'Project' {
-            $r.Parameters.Keys | Should -Contain $_
+        It 'GitSource parameter should be in all parametersets: <_>' -TestCases $command.ParameterSets.Name {
+            $command.Parameters['GitSource'].ParameterSets.Keys | Should -Contain $_
         }
-        It 'GitSource parameter should be in all parametersets: <_>' -TestCases $r.ParameterSets.Name {
-            $r.Parameters['GitSource'].ParameterSets.Keys | Should -Contain $_
+        It 'Organization parameter should be in all parametersets: <_>' -TestCases $command.ParameterSets.Name {
+            $command.Parameters['Organization'].ParameterSets.Keys | Should -Contain $_
         }
-        It 'Organization parameter should be in all parametersets: <_>' -TestCases $r.ParameterSets.Name {
-            $r.Parameters['Organization'].ParameterSets.Keys | Should -Contain $_
-        }
-        It 'Project parameter should be in all parametersets: <_>' -TestCases $r.ParameterSets.Name {
-            $r.Parameters['Project'].ParameterSets.Keys | Should -Contain $_
+        It 'Project parameter should be in all parametersets: <_>' -TestCases $command.ParameterSets.Name {
+            $command.Parameters['Project'].ParameterSets.Keys | Should -Contain $_
         }
         It 'RepositoryId parameter should only be in RepositoryId ParameterSet' {
-            $r.Parameters['RepositoryID'].ParameterSets.Keys | Should -Be 'RepositoryId'
+            $command.Parameters['RepositoryID'].ParameterSets.Keys | Should -Be 'RepositoryId'
         }
         It 'RepositoryName parameter should only be in RepositoryName ParameterSet' {
-            $r.Parameters['RepositoryName'].ParameterSets.Keys | Should -Be 'RepositoryName'
+            $command.Parameters['RepositoryName'].ParameterSets.Keys | Should -Be 'RepositoryName'
         }
         It 'Default ParameterSet should be "RepositoryName"' {
-            $r.DefaultParameterSet | Should -Be 'RepositoryName'
+            $command.DefaultParameterSet | Should -Be 'RepositoryName'
         }
     }
 

--- a/Tests/Import-ADOPSRepository.Tests.ps1
+++ b/Tests/Import-ADOPSRepository.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Import-ADOPSRepository' {
     Context 'Command structure' {
@@ -51,7 +53,7 @@ Describe 'Import-ADOPSRepository' {
                         Organization = 'DummyOrg'
                     }
                 }
-                
+
                 Mock -CommandName InvokeADOPSRestMethod  -ModuleName ADOPS -MockWith {
                     return $InvokeSplat
                 }
@@ -66,7 +68,7 @@ Describe 'Import-ADOPSRepository' {
             $r = Import-ADOPSRepository -GitSource 'GitSource' -RepositoryName 'RepoName' -Project 'DummyProj'
             Should -Invoke -CommandName GetADOPSHeader -ModuleName ADOPS
         }
-        
+
         It 'Invoke should be correct, Verifying method "Post"' {
             $r = Import-ADOPSRepository -GitSource 'GitSource' -RepositoryName 'RepoName' -Project 'DummyProj'
             $r.Method | Should -Be 'Post'

--- a/Tests/InvokeADOPSRestMethod.Tests.ps1
+++ b/Tests/InvokeADOPSRestMethod.Tests.ps1
@@ -21,7 +21,7 @@ InModuleScope -ModuleName ADOPS {
             @{ Name = 'ContentType' }
             @{ Name = 'FullResponse'; Type = [switch] }
         ) {
-            Get-Command -Name InvokeADOPSRestMethod | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            Get-Command -Name InvokeADOPSRestMethod | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
 
         Context 'Building webrequest call' {

--- a/Tests/InvokeADOPSRestMethod.Tests.ps1
+++ b/Tests/InvokeADOPSRestMethod.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 
 InModuleScope -ModuleName ADOPS {
@@ -30,7 +32,7 @@ InModuleScope -ModuleName ADOPS {
             It 'Should have parameter FullResponse' {
                 (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'FullResponse'
             }
-            
+
             It 'Uri should be mandatory' {
                 (Get-Command InvokeADOPSRestMethod).Parameters['uri'].Attributes.Mandatory | Should -Be $true
             }
@@ -115,13 +117,13 @@ InModuleScope -ModuleName ADOPS {
                     Mock -CommandName Invoke-RestMethod -ModuleName ADOPS -MockWith {
                         return '<html lang="en-US">
                         <head><title>
-                        
+
                                     Azure DevOps Services | Sign In
-                        
+
                         </title><meta http-equiv="X-UA-Compatible" content="IE=11;&#32;IE=10;&#32;IE=9;&#32;IE=8" />
                             <link rel="SHORTCUT ICON" href="/favicon.ico"/>'
                     }
-    
+
                     {InvokeADOPSRestMethod @PostObject} | Should -Throw
                     Should -Invoke Invoke-RestMethod -ModuleName ADOPS -Exactly 1
                     Should -Invoke GetADOPSHeader -ModuleName ADOPS -Exactly 1
@@ -143,7 +145,7 @@ InModuleScope -ModuleName ADOPS {
                         Set-Variable -Scope Script -Name $PesterBoundParameters.StatusCodeVariable -Value 200
                         return @{foo = 'bar'}
                     }
-    
+
                     $response = InvokeADOPSRestMethod @PostObject -FullResponse
                     Should -Invoke Invoke-RestMethod -ModuleName ADOPS -Exactly 1
                     Should -Invoke GetADOPSHeader -ModuleName ADOPS -Exactly 1

--- a/Tests/InvokeADOPSRestMethod.Tests.ps1
+++ b/Tests/InvokeADOPSRestMethod.Tests.ps1
@@ -13,36 +13,17 @@ InModuleScope -ModuleName ADOPS {
                 Body = @{Dummy='value'} | ConvertTo-Json
             }
         }
-        Context 'Parameters' {
-            It 'Should have parameter method' {
-                (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'method'
-            }
-            It 'Should have parameter body' {
-                (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'body'
-            }
-            It 'Should have parameter uri' {
-                (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'uri'
-            }
-            It 'Should have parameter Organization' {
-                (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Should have parameter ContentType' {
-                (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'ContentType'
-            }
-            It 'Should have parameter FullResponse' {
-                (Get-Command InvokeADOPSRestMethod).Parameters.Keys | Should -Contain 'FullResponse'
-            }
-
-            It 'Uri should be mandatory' {
-                (Get-Command InvokeADOPSRestMethod).Parameters['uri'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Uri should be of type URI' {
-                (Get-Command InvokeADOPSRestMethod).Parameters['uri'].ParameterType.Name | Should -Be 'URI'
-            }
-            It 'Method should be of type WebRequestMethod' {
-                (Get-Command InvokeADOPSRestMethod).Parameters['Method'].ParameterType.Name | Should -Be 'WebRequestMethod'
-            }
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Method'; Type = [Microsoft.PowerShell.Commands.WebRequestMethod] }
+            @{ Name = 'Body'; }
+            @{ Name = 'Uri'; Mandatory = $true; Type = [URI] }
+            @{ Name = 'Organization' }
+            @{ Name = 'ContentType' }
+            @{ Name = 'FullResponse'; Type = [switch] }
+        ) {
+            Get-Command -Name InvokeADOPSRestMethod | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
+
         Context 'Building webrequest call' {
             BeforeEach {
                 Mock -CommandName GetADOPSHeader -MockWith {

--- a/Tests/InvokeADOPSRestMethod.Tests.ps1
+++ b/Tests/InvokeADOPSRestMethod.Tests.ps1
@@ -13,15 +13,17 @@ InModuleScope -ModuleName ADOPS {
                 Body = @{Dummy='value'} | ConvertTo-Json
             }
         }
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Method'; Type = [Microsoft.PowerShell.Commands.WebRequestMethod] }
-            @{ Name = 'Body'; }
-            @{ Name = 'Uri'; Mandatory = $true; Type = [URI] }
-            @{ Name = 'Organization' }
-            @{ Name = 'ContentType' }
-            @{ Name = 'FullResponse'; Type = [switch] }
-        ) {
-            Get-Command -Name InvokeADOPSRestMethod | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Context 'Parameter validation' {
+            It 'Has parameter <_.Name>' -TestCases @(
+                @{ Name = 'Method'; Type = [Microsoft.PowerShell.Commands.WebRequestMethod] }
+                @{ Name = 'Body'; }
+                @{ Name = 'Uri'; Mandatory = $true; Type = [URI] }
+                @{ Name = 'Organization' }
+                @{ Name = 'ContentType' }
+                @{ Name = 'FullResponse'; Type = [switch] }
+            ) {
+                Get-Command -Name InvokeADOPSRestMethod | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            }
         }
 
         Context 'Building webrequest call' {

--- a/Tests/Module.tests.ps1
+++ b/Tests/Module.tests.ps1
@@ -3,64 +3,59 @@
     Only functions located in the Public folder should be exported.
 #>
 
-#region Set up test cases
-$ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    # actual exported functions
+    $ExportedFunctions = (Get-Module -FullyQualifiedName "$PSScriptRoot\..\Source\ADOPS.psd1" -ListAvailable -Refresh).ExportedFunctions.Keys
 
-# actual exported functions
-$ExportedFunctions = (Get-Module -FullyQualifiedName "$ScriptDirectory\..\Source\ADOPS.psd1" -ListAvailable -Refresh).ExportedFunctions.Keys
-$ModuleName = (Get-ChildItem -Path "$ScriptDirectory\..\Source\ADOPS.psm1").BaseName
+    # Create test cases for public functions
+    if (Test-Path -Path "$PSScriptRoot\..\Source\Public" -PathType Container) {
+        $PublicFiles = Get-Childitem "$PSScriptRoot\..\Source\Public\*.ps1"
+        $PublicFunctions = $PublicFiles.Name -replace '\.ps1$'
 
-# Create test cases for public functions
-if (Test-Path -Path "$ScriptDirectory\..\Source\Public" -PathType Container) {
-    $PublicFiles = Get-Childitem "$ScriptDirectory\..\Source\Public\*.ps1"
-    $PublicFunctions = $PublicFiles.Name -replace '\.ps1$'
-
-    $PublicTestCases = @()
-    $ParametersTestCases = @()
-    foreach ($PublicFunction in $PublicFunctions) {
-        $PublicTestCases += @{
-            Function = $PublicFunction
-            ExportedFunctions = $ExportedFunctions
-        }
-        $Parameters = (Get-Command $PublicFunction).Parameters.GetEnumerator() | Where-Object {
-            $_.Key -notin [System.Management.Automation.Cmdlet]::CommonParameters -and
-            $_.Value.Attributes.DontShow -eq $false
-        } | Select-Object -ExpandProperty Key
-        foreach ($Parameter in $Parameters) {
-            $ParametersTestCases += @{
+        $PublicTestCases = @()
+        $ParametersTestCases = @()
+        foreach ($PublicFunction in $PublicFunctions) {
+            $PublicTestCases += @{
                 Function = $PublicFunction
-                Parameter = $Parameter
+                ExportedFunctions = $ExportedFunctions
+            }
+            $Parameters = (Get-Command $PublicFunction).Parameters.GetEnumerator() | Where-Object {
+                $_.Key -notin [System.Management.Automation.Cmdlet]::CommonParameters -and
+                $_.Value.Attributes.DontShow -eq $false
+            } | Select-Object -ExpandProperty Key
+            foreach ($Parameter in $Parameters) {
+                $ParametersTestCases += @{
+                    Function = $PublicFunction
+                    Parameter = $Parameter
+                }
             }
         }
     }
-}
 
-# Create test cases for private functions
-if (Test-Path -Path "$ScriptDirectory\..\Source\Private" -PathType Container) {
-    $PrivateFiles = Get-Childitem "$ScriptDirectory\..\Source\Private\*.ps1"
-    $PrivateFunctions = $PrivateFiles.Name -replace '\.ps1$'
+    # Create test cases for private functions
+    if (Test-Path -Path "$PSScriptRoot\..\Source\Private" -PathType Container) {
+        $PrivateFiles = Get-Childitem "$PSScriptRoot\..\Source\Private\*.ps1"
+        $PrivateFunctions = $PrivateFiles.Name -replace '\.ps1$'
 
-    $PrivateTestCases = @()
-    foreach ($PrivateFunction in $PrivateFunctions) {
-        $PrivateTestCases += @{
-            Function = $PrivateFunction
-            ExportedFunctions = $ExportedFunctions
+        $PrivateTestCases = @()
+        foreach ($PrivateFunction in $PrivateFunctions) {
+            $PrivateTestCases += @{
+                Function = $PrivateFunction
+                ExportedFunctions = $ExportedFunctions
+            }
         }
     }
+
+    Initialize-TestSetup
 }
 
-# Import the module files before starting tests
-BeforeAll {
-    $ScriptDirectory = Split-Path -Path $PSCommandPath -Parent
-    Import-Module -FullyQualifiedName "$ScriptDirectory\..\Source\ADOPS.psd1" -ErrorAction Stop
-}
+Describe "Module AZDOPS" {
 
-Describe "Module $ModuleName" {
-    
     # A module should always have public functions
     # Its technically possible to not have any public functions. In that case, modify this script.
     Context 'Validate public functions' {
-        
+
         It "Exported functions exist" -TestCases (@{ Count = $PublicTestCases.count }) {
             param ( $Count )
             $Count | Should -BeGreaterThan 0 -Because 'functions should exist'
@@ -73,19 +68,19 @@ Describe "Module $ModuleName" {
         }
         It "Public function '<Function>' should have a CmdLet file in correct place." -TestCases $PublicTestCases {
             param ( $Function )
-            Test-Path -Path "$ScriptDirectory\..\Source\Public\$Function.ps1" -PathType Leaf | Should -Be $true
+            Test-Path -Path "$PSScriptRoot\..\Source\Public\$Function.ps1" -PathType Leaf | Should -Be $true
         }
         It "Public function '<Function>' should have a test file." -TestCases $PublicTestCases {
             param ( $Function )
-            Test-Path -Path "$ScriptDirectory\$Function.Tests.ps1" -PathType Leaf | Should -Be $true
+            Test-Path -Path "$PSScriptRoot\$Function.Tests.ps1" -PathType Leaf | Should -Be $true
         }
         It "Public function '<Function>' should have a Docs/Help file." -TestCases $PublicTestCases {
             param ( $Function )
-            Test-Path -Path "$ScriptDirectory\..\Docs\Help\$Function.md" -PathType Leaf | Should -Be $true
+            Test-Path -Path "$PSScriptRoot\..\Docs\Help\$Function.md" -PathType Leaf | Should -Be $true
         }
         It "Docs/Help file for '<Function>' contains parameter '<Parameter>'." -TestCases $ParametersTestCases {
             param ( $Function, $Parameter )
-            "$ScriptDirectory\..\Docs\Help\$Function.md" | Should -FileContentMatch $Parameter
+            "$PSScriptRoot\..\Docs\Help\$Function.md" | Should -FileContentMatch $Parameter
         }
 
         # This test only works on compiled psd1 files, and can tbe run in current build script. needs to be revisited.
@@ -104,11 +99,11 @@ Describe "Module $ModuleName" {
             }
             It "Private function '<Function>' should have a CmdLet file in correct place." -TestCases $PrivateTestCases {
                 param ( $Function )
-                Test-Path -Path "$ScriptDirectory\..\Source\Private\$Function.ps1" -PathType Leaf | Should -Be $true
+                Test-Path -Path "$PSScriptRoot\..\Source\Private\$Function.ps1" -PathType Leaf | Should -Be $true
             }
             It "Private function '<Function>' should have a test file." -TestCases $PrivateTestCases {
                 param ( $Function )
-                Test-Path -Path "$ScriptDirectory\$Function.Tests.ps1" -PathType Leaf | Should -Be $true
+                Test-Path -Path "$PSScriptRoot\$Function.Tests.ps1" -PathType Leaf | Should -Be $true
             }
         }
     }

--- a/Tests/New-ADOPSElasticPoolObject.Tests.ps1
+++ b/Tests/New-ADOPSElasticPoolObject.Tests.ps1
@@ -18,7 +18,7 @@ Describe "New-ADOPSElasticPoolObject" {
         @{ Name = 'MaxSavedNodeCount'; }
         @{ Name = 'OutputType'; }
     ) {
-        Get-Command -Name New-ADOPSElasticPoolObject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSElasticPoolObject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/New-ADOPSElasticPoolObject.Tests.ps1
+++ b/Tests/New-ADOPSElasticPoolObject.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "New-ADOPSElasticPoolObject" {
     Context "Function tests" {

--- a/Tests/New-ADOPSElasticPoolObject.Tests.ps1
+++ b/Tests/New-ADOPSElasticPoolObject.Tests.ps1
@@ -4,14 +4,21 @@ BeforeDiscovery {
 }
 
 Describe "New-ADOPSElasticPoolObject" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name New-ADOPSElasticPoolObject -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'ServiceEndpointId', 'ServiceEndpointScope', 'AzureId', 'OsType', 'MaxCapacity', 'DesiredIdle', 'RecycleAfterEachUse', 'DesiredSize', 'AgentInteractiveUI', 'TimeToLiveMinues', 'MaxSavedNodeCount', 'OutputType' {
-            (Get-Command -Name New-ADOPSElasticPoolObject).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'ServiceEndpointId'; Mandatory = $true }
+        @{ Name = 'ServiceEndpointScope'; Mandatory = $true }
+        @{ Name = 'AzureId'; Mandatory = $true }
+        @{ Name = 'OsType'; }
+        @{ Name = 'MaxCapacity'; }
+        @{ Name = 'DesiredIdle'; }
+        @{ Name = 'RecycleAfterEachUse'; }
+        @{ Name = 'DesiredSize'; }
+        @{ Name = 'AgentInteractiveUI'; }
+        @{ Name = 'TimeToLiveMinues'; }
+        @{ Name = 'MaxSavedNodeCount'; }
+        @{ Name = 'OutputType'; }
+    ) {
+        Get-Command -Name New-ADOPSElasticPoolObject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/New-ADOPSElasticPoolObject.Tests.ps1
+++ b/Tests/New-ADOPSElasticPoolObject.Tests.ps1
@@ -4,21 +4,23 @@ BeforeDiscovery {
 }
 
 Describe "New-ADOPSElasticPoolObject" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'ServiceEndpointId'; Mandatory = $true }
-        @{ Name = 'ServiceEndpointScope'; Mandatory = $true }
-        @{ Name = 'AzureId'; Mandatory = $true }
-        @{ Name = 'OsType'; }
-        @{ Name = 'MaxCapacity'; }
-        @{ Name = 'DesiredIdle'; }
-        @{ Name = 'RecycleAfterEachUse'; }
-        @{ Name = 'DesiredSize'; }
-        @{ Name = 'AgentInteractiveUI'; }
-        @{ Name = 'TimeToLiveMinues'; }
-        @{ Name = 'MaxSavedNodeCount'; }
-        @{ Name = 'OutputType'; }
-    ) {
-        Get-Command -Name New-ADOPSElasticPoolObject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'ServiceEndpointId'; Mandatory = $true }
+            @{ Name = 'ServiceEndpointScope'; Mandatory = $true }
+            @{ Name = 'AzureId'; Mandatory = $true }
+            @{ Name = 'OsType'; }
+            @{ Name = 'MaxCapacity'; }
+            @{ Name = 'DesiredIdle'; }
+            @{ Name = 'RecycleAfterEachUse'; }
+            @{ Name = 'DesiredSize'; }
+            @{ Name = 'AgentInteractiveUI'; }
+            @{ Name = 'TimeToLiveMinues'; }
+            @{ Name = 'MaxSavedNodeCount'; }
+            @{ Name = 'OutputType'; }
+        ) {
+            Get-Command -Name New-ADOPSElasticPoolObject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/New-ADOPSElasticpool.Tests.ps1
+++ b/Tests/New-ADOPSElasticpool.Tests.ps1
@@ -12,7 +12,7 @@ Describe "New-ADOPSElasticpool" {
         @{ Name = 'AuthorizeAllPipelines' }
         @{ Name = 'AutoProvisionProjectPools' }
     ) {
-        Get-Command -Name New-ADOPSElasticPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/New-ADOPSElasticpool.Tests.ps1
+++ b/Tests/New-ADOPSElasticpool.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "New-ADOPSElasticpool" {
     Context "Function tests" {
@@ -16,7 +18,7 @@ Describe "New-ADOPSElasticpool" {
         BeforeAll {
             Mock InvokeADOPSRestMethod -ModuleName ADOPS {
                 [PSCustomObject]@{
-                    elasticPool =                                                                                                             
+                    elasticPool =
                     @{
                         poolId               = 59
                         serviceEndpointId    = '44868479-e856-42bf-9a2b-74bb500d8e36'

--- a/Tests/New-ADOPSElasticpool.Tests.ps1
+++ b/Tests/New-ADOPSElasticpool.Tests.ps1
@@ -4,14 +4,15 @@ BeforeDiscovery {
 }
 
 Describe "New-ADOPSElasticpool" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name New-ADOPSElasticpool -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'Organization', 'ElasticPoolObject', 'ProjectId', 'PoolName', 'AuthorizeAllPipelines', 'AutoProvisionProjectPools' {
-            (Get-Command -Name New-ADOPSElasticpool).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'PoolName'; Mandatory = $true }
+        @{ Name = 'ElasticPoolObject'; Mandatory = $true }
+        @{ Name = 'ProjectId' }
+        @{ Name = 'Organization' }
+        @{ Name = 'AuthorizeAllPipelines' }
+        @{ Name = 'AutoProvisionProjectPools' }
+    ) {
+        Get-Command -Name New-ADOPSElasticPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/New-ADOPSElasticpool.Tests.ps1
+++ b/Tests/New-ADOPSElasticpool.Tests.ps1
@@ -4,15 +4,17 @@ BeforeDiscovery {
 }
 
 Describe "New-ADOPSElasticpool" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'PoolName'; Mandatory = $true }
-        @{ Name = 'ElasticPoolObject'; Mandatory = $true }
-        @{ Name = 'ProjectId' }
-        @{ Name = 'Organization' }
-        @{ Name = 'AuthorizeAllPipelines' }
-        @{ Name = 'AutoProvisionProjectPools' }
-    ) {
-        Get-Command -Name New-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'PoolName'; Mandatory = $true }
+            @{ Name = 'ElasticPoolObject'; Mandatory = $true }
+            @{ Name = 'ProjectId' }
+            @{ Name = 'Organization' }
+            @{ Name = 'AuthorizeAllPipelines' }
+            @{ Name = 'AutoProvisionProjectPools' }
+        ) {
+            Get-Command -Name New-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/New-ADOPSPipeline.Tests.ps1
+++ b/Tests/New-ADOPSPipeline.Tests.ps1
@@ -4,17 +4,20 @@ BeforeDiscovery {
 }
 
 InModuleScope -ModuleName ADOPS {
-    Describe 'New-ADOPSPipeline tests' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Name'; Mandatory = $true }
-            @{ Name = 'Project'; Mandatory = $true }
-            @{ Name = 'YamlPath'; Mandatory = $true }
-            @{ Name = 'Repository'; Mandatory = $true }
-            @{ Name = 'FolderPath'; }
-            @{ Name = 'Organization'; }
-        ) {
-            Get-Command -Name New-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Describe 'New-ADOPSPipeline' {
+        Context 'Parameter validation' {
+            It 'Has parameter <_.Name>' -TestCases @(
+                @{ Name = 'Name'; Mandatory = $true }
+                @{ Name = 'Project'; Mandatory = $true }
+                @{ Name = 'YamlPath'; Mandatory = $true }
+                @{ Name = 'Repository'; Mandatory = $true }
+                @{ Name = 'FolderPath'; }
+                @{ Name = 'Organization'; }
+            ) {
+                Get-Command -Name New-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            }
         }
+
         Context 'Creating Pipeline' {
             BeforeAll {
 

--- a/Tests/New-ADOPSPipeline.Tests.ps1
+++ b/Tests/New-ADOPSPipeline.Tests.ps1
@@ -13,7 +13,7 @@ InModuleScope -ModuleName ADOPS {
             @{ Name = 'FolderPath'; }
             @{ Name = 'Organization'; }
         ) {
-            Get-Command -Name New-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            Get-Command -Name New-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
         Context 'Creating Pipeline' {
             BeforeAll {

--- a/Tests/New-ADOPSPipeline.Tests.ps1
+++ b/Tests/New-ADOPSPipeline.Tests.ps1
@@ -5,6 +5,16 @@ BeforeDiscovery {
 
 InModuleScope -ModuleName ADOPS {
     Describe 'New-ADOPSPipeline tests' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'YamlPath'; Mandatory = $true }
+            @{ Name = 'Repository'; Mandatory = $true }
+            @{ Name = 'FolderPath'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
         Context 'Creating Pipeline' {
             BeforeAll {
 
@@ -86,45 +96,6 @@ InModuleScope -ModuleName ADOPS {
             }
             It 'should not throw without optional parameters' {
                 { New-ADOPSPipeline -Project $Project -Name $PipeName -YamlPath $YamlPath -Repository $Repository} | Should -Not -Throw
-            }
-        }
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command New-ADOPSPipeline).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Organization should not be required' {
-                (Get-Command New-ADOPSPipeline).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Project' {
-                (Get-Command New-ADOPSPipeline).Parameters.Keys | Should -Contain 'Project'
-            }
-            It 'Project should be required' {
-                (Get-Command New-ADOPSPipeline).Parameters['Project'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter Name' {
-                (Get-Command New-ADOPSPipeline).Parameters.Keys | Should -Contain 'Name'
-            }
-            It 'Name should be required' {
-                (Get-Command New-ADOPSPipeline).Parameters['Name'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter YamlPath' {
-                (Get-Command New-ADOPSPipeline).Parameters.Keys | Should -Contain 'YamlPath'
-            }
-            It 'YamlPath should be required' {
-                (Get-Command New-ADOPSPipeline).Parameters['YamlPath'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter Repository' {
-                (Get-Command New-ADOPSPipeline).Parameters.Keys | Should -Contain 'Repository'
-            }
-            It 'Repository should be required' {
-                (Get-Command New-ADOPSPipeline).Parameters['Repository'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter FolderPath' {
-                (Get-Command New-ADOPSPipeline).Parameters.Keys | Should -Contain 'FolderPath'
-            }
-            It 'FolderPath should not be required' {
-                (Get-Command New-ADOPSPipeline).Parameters['FolderPath'].Attributes.Mandatory | Should -Be $false
             }
         }
     }

--- a/Tests/New-ADOPSPipeline.Tests.ps1
+++ b/Tests/New-ADOPSPipeline.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'New-ADOPSPipeline tests' {
@@ -28,7 +30,7 @@ InModuleScope -ModuleName ADOPS {
                         Organization = $OrganizationName
                     }
                 }
-                
+
                 Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
                     return $InvokeSplat
                 } -ParameterFilter { $method -eq 'Post' }
@@ -126,4 +128,4 @@ InModuleScope -ModuleName ADOPS {
             }
         }
     }
-} 
+}

--- a/Tests/New-ADOPSProject.tests.ps1
+++ b/Tests/New-ADOPSProject.tests.ps1
@@ -5,6 +5,16 @@ BeforeDiscovery {
 
 InModuleScope -ModuleName ADOPS {
     Describe 'New-ADOPSProject tests' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; Mandatory = $true }
+            @{ Name = 'Visibility'; Mandatory = $true }
+            @{ Name = 'SourceControlType'; }
+            @{ Name = 'ProcessTypeName'; }
+            @{ Name = 'Description'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSProject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
         Context 'Creating project' {
             BeforeAll {
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
@@ -100,45 +110,6 @@ InModuleScope -ModuleName ADOPS {
                 (New-ADOPSProject -Organization $OrganizationName -Name $Project -Visibility 'Public' -Description 'DummyDescription').Body | ConvertFrom-Json | Select-Object -ExpandProperty Description | Should -Be 'DummyDescription'
             }
 
-        }
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command New-ADOPSProject).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Organization should not be required' {
-                (Get-Command New-ADOPSProject).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Name' {
-                (Get-Command New-ADOPSProject).Parameters.Keys | Should -Contain 'Name'
-            }
-            It 'Name should be required' {
-                (Get-Command New-ADOPSProject).Parameters['Name'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter Description' {
-                (Get-Command New-ADOPSProject).Parameters.Keys | Should -Contain 'Description'
-            }
-            It 'Description should not be required' {
-                (Get-Command New-ADOPSProject).Parameters['Description'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Visibility' {
-                (Get-Command New-ADOPSProject).Parameters.Keys | Should -Contain 'Visibility'
-            }
-            It 'Visibility should be required' {
-                (Get-Command New-ADOPSProject).Parameters['Visibility'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter SourceControlType' {
-                (Get-Command New-ADOPSProject).Parameters.Keys | Should -Contain 'SourceControlType'
-            }
-            It 'SourceControlType should be required' {
-                (Get-Command New-ADOPSProject).Parameters['SourceControlType'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter ProcessTypeName' {
-                (Get-Command New-ADOPSProject).Parameters.Keys | Should -Contain 'ProcessTypeName'
-            }
-            It 'ProcessTypeName should be required' {
-                (Get-Command New-ADOPSProject).Parameters['ProcessTypeName'].Attributes.Mandatory | Should -Be $false
-            }
         }
     }
 }

--- a/Tests/New-ADOPSProject.tests.ps1
+++ b/Tests/New-ADOPSProject.tests.ps1
@@ -4,17 +4,20 @@ BeforeDiscovery {
 }
 
 InModuleScope -ModuleName ADOPS {
-    Describe 'New-ADOPSProject tests' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'Name'; Mandatory = $true }
-            @{ Name = 'Visibility'; Mandatory = $true }
-            @{ Name = 'SourceControlType'; }
-            @{ Name = 'ProcessTypeName'; }
-            @{ Name = 'Description'; }
-            @{ Name = 'Organization'; }
-        ) {
-            Get-Command -Name New-ADOPSProject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Describe 'New-ADOPSProject' {
+        Context 'Parameter validation' {
+            It 'Has parameter <_.Name>' -TestCases @(
+                @{ Name = 'Name'; Mandatory = $true }
+                @{ Name = 'Visibility'; Mandatory = $true }
+                @{ Name = 'SourceControlType'; }
+                @{ Name = 'ProcessTypeName'; }
+                @{ Name = 'Description'; }
+                @{ Name = 'Organization'; }
+            ) {
+                Get-Command -Name New-ADOPSProject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            }
         }
+
         Context 'Creating project' {
             BeforeAll {
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {

--- a/Tests/New-ADOPSProject.tests.ps1
+++ b/Tests/New-ADOPSProject.tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'New-ADOPSProject tests' {

--- a/Tests/New-ADOPSProject.tests.ps1
+++ b/Tests/New-ADOPSProject.tests.ps1
@@ -13,7 +13,7 @@ InModuleScope -ModuleName ADOPS {
             @{ Name = 'Description'; }
             @{ Name = 'Organization'; }
         ) {
-            Get-Command -Name New-ADOPSProject | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+            Get-Command -Name New-ADOPSProject | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
         }
         Context 'Creating project' {
             BeforeAll {

--- a/Tests/New-ADOPSRepository.Tests.ps1
+++ b/Tests/New-ADOPSRepository.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'New-ADOPSRepository' {
     Context 'Command structure' {
@@ -39,7 +41,7 @@ Describe 'New-ADOPSRepository' {
                         Organization = 'DummyOrg'
                     }
                 }
-                
+
                 Mock -CommandName InvokeADOPSRestMethod  -ModuleName ADOPS -MockWith {
                     return $InvokeSplat
                 }
@@ -68,7 +70,7 @@ Describe 'New-ADOPSRepository' {
             $r = New-ADOPSRepository -Project 'DummyProj' -Name 'RepoName'
             Should -Invoke -CommandName GetADOPSHeader -ModuleName ADOPS
         }
-        
+
         It 'Invoke should be correct, Verifying method "Post"' {
             $r = New-ADOPSRepository -Organization 'DummyOrg' -Project 'DummyProj' -Name 'RepoName'
             $r.Method | Should -Be 'Post'

--- a/Tests/New-ADOPSRepository.Tests.ps1
+++ b/Tests/New-ADOPSRepository.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'New-ADOPSRepository' {
         @{ Name = 'Project'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name New-ADOPSRepository | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Running command' {

--- a/Tests/New-ADOPSRepository.Tests.ps1
+++ b/Tests/New-ADOPSRepository.Tests.ps1
@@ -4,22 +4,12 @@ BeforeDiscovery {
 }
 
 Describe 'New-ADOPSRepository' {
-    Context 'Command structure' {
-        BeforeAll {
-            $r  = Get-Command -Name New-ADOPSRepository -Module ADOPS
-        }
-        It 'Command should exist' {
-            $r | Should -Not -BeNullOrEmpty
-        }
-        It 'Has parameter <_>' -TestCases 'Organization', 'Project', 'Name' {
-            $r.Parameters.Keys | Should -Contain $_
-        }
-        It 'Name should be mandatory' {
-            (Get-Command New-ADOPSRepository).Parameters['Name'].Attributes.Mandatory | Should -Be $true
-        }
-        It 'Project should be mandatory' {
-            (Get-Command New-ADOPSRepository).Parameters['Project'].Attributes.Mandatory | Should -Be $true
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Name'; Mandatory = $true }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name New-ADOPSRepository | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Running command' {

--- a/Tests/New-ADOPSRepository.Tests.ps1
+++ b/Tests/New-ADOPSRepository.Tests.ps1
@@ -4,12 +4,14 @@ BeforeDiscovery {
 }
 
 Describe 'New-ADOPSRepository' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Name'; Mandatory = $true }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name New-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context 'Running command' {

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -13,6 +13,6 @@ Describe 'ADOPSServiceConnection' {
         @{ Name = 'ConnectionName'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name New-ADOPSServiceConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSServiceConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 }

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -1,6 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
-
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'ADOPSServiceConnection' {
     Context 'Function tests' {

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -4,15 +4,17 @@ BeforeDiscovery {
 }
 
 Describe 'ADOPSServiceConnection' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'TenantId'; Mandatory = $true }
-        @{ Name = 'SubscriptionName'; Mandatory = $true }
-        @{ Name = 'SubscriptionId'; Mandatory = $true }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'ServicePrincipal'; Mandatory = $true }
-        @{ Name = 'ConnectionName'; }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name New-ADOPSServiceConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'TenantId'; Mandatory = $true }
+            @{ Name = 'SubscriptionName'; Mandatory = $true }
+            @{ Name = 'SubscriptionId'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'ServicePrincipal'; Mandatory = $true }
+            @{ Name = 'ConnectionName'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSServiceConnection | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 }

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -4,10 +4,15 @@ BeforeDiscovery {
 }
 
 Describe 'ADOPSServiceConnection' {
-    Context 'Function tests' {
-        It 'We have a function' {
-            Get-Command New-ADOPSServiceConnection -Module ADOPS | Should -Not -BeNullOrEmpty
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'TenantId'; Mandatory = $true }
+        @{ Name = 'SubscriptionName'; Mandatory = $true }
+        @{ Name = 'SubscriptionId'; Mandatory = $true }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'ServicePrincipal'; Mandatory = $true }
+        @{ Name = 'ConnectionName'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name New-ADOPSServiceConnection | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 }
-

--- a/Tests/New-ADOPSUserStory.Tests.ps1
+++ b/Tests/New-ADOPSUserStory.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'New-ADOPSUserStory tests' {

--- a/Tests/New-ADOPSUserStory.Tests.ps1
+++ b/Tests/New-ADOPSUserStory.Tests.ps1
@@ -3,48 +3,17 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-InModuleScope -ModuleName ADOPS {
-    Describe 'New-ADOPSUserStory tests' {
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command New-ADOPSUserStory).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Should have parameter ProjectName' {
-                (Get-Command New-ADOPSUserStory).Parameters.Keys | Should -Contain 'ProjectName'
-            }
-            It 'ProjectName should be required' {
-                (Get-Command New-ADOPSUserStory).Parameters['ProjectName'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter Title' {
-                (Get-Command New-ADOPSUserStory).Parameters.Keys | Should -Contain 'Title'
-            }
-            It 'Title should be required' {
-                (Get-Command New-ADOPSUserStory).Parameters['Title'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter Description' {
-                (Get-Command New-ADOPSUserStory).Parameters.Keys | Should -Contain 'Description'
-            }
-            It 'Description should not be required' {
-                (Get-Command New-ADOPSUserStory).Parameters['Description'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Tags' {
-                (Get-Command New-ADOPSUserStory).Parameters.Keys | Should -Contain 'Tags'
-            }
-            It 'Tags should not be required' {
-                (Get-Command New-ADOPSUserStory).Parameters['Tags'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Priority' {
-                (Get-Command New-ADOPSUserStory).Parameters.Keys | Should -Contain 'Priority'
-            }
-            It 'Priority should not be required' {
-                (Get-Command New-ADOPSUserStory).Parameters['Priority'].Attributes.Mandatory | Should -Be $false
-            }
-        }
-    }
-}
-
 Describe 'New-ADOPSUserStory' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Title'; Mandatory = $true }
+        @{ Name = 'ProjectName'; Mandatory = $true }
+        @{ Name = 'Description'; }
+        @{ Name = 'Tags'; }
+        @{ Name = 'Priority'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name New-ADOPSUserStory | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
     Context 'Creating new user story' {
         BeforeAll {
             InModuleScope -ModuleName ADOPS {

--- a/Tests/New-ADOPSUserStory.Tests.ps1
+++ b/Tests/New-ADOPSUserStory.Tests.ps1
@@ -1,5 +1,3 @@
-#Requires -Module @{ ModuleName = 'Pester'; ModuleVersion = '5.3.1' }
-
 Remove-Module ADOPS -ErrorAction SilentlyContinue
 Import-Module $PSScriptRoot\..\Source\ADOPS
 
@@ -71,7 +69,7 @@ Describe 'New-ADOPSUserStory' {
             }
 
             $TestRunSplat = @{
-                Organization = 'DummyOrg' 
+                Organization = 'DummyOrg'
                 ProjectName = 'DummyProj'
                 Title = 'USTitle'
                 Description = 'USDescription'
@@ -79,7 +77,7 @@ Describe 'New-ADOPSUserStory' {
                 Priority = 'USPrio'
             }
         }
-        
+
         It 'Should have called mock InvokeADOPSRestMethod' {
             $TesRes = New-ADOPSUserStory @TestRunSplat
             Should -Invoke -CommandName 'InvokeADOPSRestMethod' -Exactly 1 -ModuleName ADOPS
@@ -88,7 +86,7 @@ Describe 'New-ADOPSUserStory' {
             $TesRes = New-ADOPSUserStory @TestRunSplat
             Should -Invoke -CommandName 'GetADOPSHeader' -Exactly 1 -ModuleName ADOPS
         }
-        
+
         It 'Verifying post object, ContentType' {
             $TesRes = New-ADOPSUserStory @TestRunSplat
             $TesRes.ContentType | Should -Be "application/json-patch+json"

--- a/Tests/New-ADOPSUserStory.Tests.ps1
+++ b/Tests/New-ADOPSUserStory.Tests.ps1
@@ -4,16 +4,19 @@ BeforeDiscovery {
 }
 
 Describe 'New-ADOPSUserStory' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Title'; Mandatory = $true }
-        @{ Name = 'ProjectName'; Mandatory = $true }
-        @{ Name = 'Description'; }
-        @{ Name = 'Tags'; }
-        @{ Name = 'Priority'; }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name New-ADOPSUserStory | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Title'; Mandatory = $true }
+            @{ Name = 'ProjectName'; Mandatory = $true }
+            @{ Name = 'Description'; }
+            @{ Name = 'Tags'; }
+            @{ Name = 'Priority'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSUserStory | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
+
     Context 'Creating new user story' {
         BeforeAll {
             InModuleScope -ModuleName ADOPS {

--- a/Tests/New-ADOPSUserStory.Tests.ps1
+++ b/Tests/New-ADOPSUserStory.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'New-ADOPSUserStory' {
         @{ Name = 'Priority'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name New-ADOPSUserStory | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSUserStory | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
     Context 'Creating new user story' {
         BeforeAll {

--- a/Tests/New-ADOPSVariableGroup.Tests.ps1
+++ b/Tests/New-ADOPSVariableGroup.Tests.ps1
@@ -4,16 +4,17 @@ BeforeDiscovery {
 }
 
 Describe "New-ADOPSVariableGroup" {
-    Context "General function tests" {
-        It "Function exist" {
-            { Get-Command -Name New-ADOPSVariableGroup -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-    }
-
-    Context "Check that we have all the parameters we need" {
-        It "Contains parameter: <_>" -TestCases 'Organization', 'Project', 'VariableGroupName', 'VariableName', 'VariableValue', 'IsSecret', 'Description', 'VariableHashtable' {
-            (Get-Command -Name New-ADOPSVariableGroup).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'VariableGroupName'; Mandatory = $true }
+        @{ Name = 'VariableName'; Mandatory = $true }
+        @{ Name = 'VariableValue'; Mandatory = $true }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'VariableHashTable'; Mandatory = $true }
+        @{ Name = 'IsSecret'; Type = [switch] }
+        @{ Name = 'Description'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name New-ADOPSVariableGroup | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Adding variable group" {

--- a/Tests/New-ADOPSVariableGroup.Tests.ps1
+++ b/Tests/New-ADOPSVariableGroup.Tests.ps1
@@ -14,7 +14,7 @@ Describe "New-ADOPSVariableGroup" {
         @{ Name = 'Description'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name New-ADOPSVariableGroup | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Adding variable group" {

--- a/Tests/New-ADOPSVariableGroup.Tests.ps1
+++ b/Tests/New-ADOPSVariableGroup.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "New-ADOPSVariableGroup" {
     Context "General function tests" {
@@ -63,6 +65,6 @@ Describe "New-ADOPSVariableGroup" {
 
         It "Should invoke corret Uri when organization is used" {
             (New-ADOPSVariableGroup -Organization "someorg" -Project "myproject" -VariableGroupName "mygroup" -VariableName "myvar" -VariableValue "myvalue").Uri | Should -Be "https://dev.azure.com/someorg/_apis/distributedtask/variablegroups?api-version=7.1-preview.2"
-        }        
+        }
     }
 }

--- a/Tests/New-ADOPSVariableGroup.Tests.ps1
+++ b/Tests/New-ADOPSVariableGroup.Tests.ps1
@@ -4,17 +4,19 @@ BeforeDiscovery {
 }
 
 Describe "New-ADOPSVariableGroup" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'VariableGroupName'; Mandatory = $true }
-        @{ Name = 'VariableName'; Mandatory = $true }
-        @{ Name = 'VariableValue'; Mandatory = $true }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'VariableHashTable'; Mandatory = $true }
-        @{ Name = 'IsSecret'; Type = [switch] }
-        @{ Name = 'Description'; }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name New-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'VariableGroupName'; Mandatory = $true }
+            @{ Name = 'VariableName'; Mandatory = $true }
+            @{ Name = 'VariableValue'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'VariableHashTable'; Mandatory = $true }
+            @{ Name = 'IsSecret'; Type = [switch] }
+            @{ Name = 'Description'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Adding variable group" {

--- a/Tests/New-ADOPSWiki.Tests.ps1
+++ b/Tests/New-ADOPSWiki.Tests.ps1
@@ -37,7 +37,7 @@ Describe "New-ADOPSWiki" {
         @{ Name = 'GitBranch'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name New-ADOPSWiki | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name New-ADOPSWiki | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Functionality" {

--- a/Tests/New-ADOPSWiki.Tests.ps1
+++ b/Tests/New-ADOPSWiki.Tests.ps1
@@ -29,15 +29,17 @@ Describe "New-ADOPSWiki" {
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'WikiName'; Mandatory = $true }
-        @{ Name = 'WikiRepository'; Mandatory = $true }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'WikiRepositoryPath'; }
-        @{ Name = 'GitBranch'; }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name New-ADOPSWiki | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'WikiName'; Mandatory = $true }
+            @{ Name = 'WikiRepository'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'WikiRepositoryPath'; }
+            @{ Name = 'GitBranch'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name New-ADOPSWiki | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Functionality" {

--- a/Tests/New-ADOPSWiki.Tests.ps1
+++ b/Tests/New-ADOPSWiki.Tests.ps1
@@ -29,18 +29,15 @@ Describe "New-ADOPSWiki" {
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
-    Context "General function tests" {
-        It "Function exist" {
-            { Get-Command -Name New-ADOPSWiki -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It "Contains mandatory parameter: <_>" -TestCases 'Project', 'WikiName', 'WikiRepository' {
-            Get-Command -Name New-ADOPSWiki | Should -HaveParameter $_ -Mandatory
-        }
-
-        It "Contains non mandatory parameter: <_>" -TestCases 'Organization', 'WikiRepositoryPath', 'GitBranch' {
-            Get-Command -Name New-ADOPSWiki | Should -HaveParameter $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'WikiName'; Mandatory = $true }
+        @{ Name = 'WikiRepository'; Mandatory = $true }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'WikiRepositoryPath'; }
+        @{ Name = 'GitBranch'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name New-ADOPSWiki | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Functionality" {

--- a/Tests/New-ADOPSWiki.Tests.ps1
+++ b/Tests/New-ADOPSWiki.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "New-ADOPSWiki" {
     BeforeAll {
@@ -57,7 +59,7 @@ Describe "New-ADOPSWiki" {
             New-ADOPSWiki -Project 'myproject' -WikiName 'MyWikiName' -WikiRepository 'MyWikiRepo'
             Should -Invoke Get-ADOPSProject -ModuleName ADOPS -Times 1 -Exactly
         }
-        
+
         It 'Should call Get-ADOPSRepository once to get Repository id' {
             New-ADOPSWiki -Project 'myproject' -WikiName 'MyWikiName' -WikiRepository 'MyWikiRepo'
             Should -Invoke Get-ADOPSRepository -ModuleName ADOPS -Times 1 -Exactly

--- a/Tests/Remove-ADOPSRepository.Tests.ps1
+++ b/Tests/Remove-ADOPSRepository.Tests.ps1
@@ -21,12 +21,14 @@ Describe 'Remove-ADOPSRepository' {
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'RepositoryID'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Remove-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'RepositoryID'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Remove-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Functionality" {

--- a/Tests/Remove-ADOPSRepository.Tests.ps1
+++ b/Tests/Remove-ADOPSRepository.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Remove-ADOPSRepository' {
     BeforeAll {
@@ -15,7 +17,7 @@ Describe 'Remove-ADOPSRepository' {
                 Organization = "anotherOrg"
             }
         }
-        
+
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
@@ -71,7 +73,7 @@ Describe 'Remove-ADOPSRepository' {
             $r = Remove-ADOPSRepository -Project 'myproj' -RepositoryID $RepositoryID
             $r.name | Should -Be 'HasNoValue'
         }
-        
+
         It 'Verifying URI' {
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
                 return $URI

--- a/Tests/Remove-ADOPSRepository.Tests.ps1
+++ b/Tests/Remove-ADOPSRepository.Tests.ps1
@@ -26,7 +26,7 @@ Describe 'Remove-ADOPSRepository' {
         @{ Name = 'RepositoryID'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Remove-ADOPSRepository | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Remove-ADOPSRepository | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Functionality" {

--- a/Tests/Remove-ADOPSRepository.Tests.ps1
+++ b/Tests/Remove-ADOPSRepository.Tests.ps1
@@ -21,18 +21,12 @@ Describe 'Remove-ADOPSRepository' {
         Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
     }
 
-    Context "General function tests" {
-        It "Function exist" {
-            { Get-Command -Name Remove-ADOPSRepository -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It "Contains non mandatory parameter: <_>" -TestCases 'Organization' {
-            Get-Command -Name Remove-ADOPSRepository | Should -HaveParameter $_
-        }
-
-        It "Contains mandatory parameter: <_>" -TestCases 'Project', 'RepositoryID' {
-            Get-Command -Name Remove-ADOPSRepository | Should -HaveParameter $_ -Mandatory
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'RepositoryID'; Mandatory = $true }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Remove-ADOPSRepository | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Functionality" {

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 InModuleScope -ModuleName ADOPS {
     Describe 'Remove-ADOPSVariableGroup tests' {

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -9,7 +9,7 @@ Describe 'Remove-ADOPSVariableGroup' {
         @{ Name = 'Project'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
     Context 'Removing variable group' {
         BeforeAll {

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -4,13 +4,16 @@ BeforeDiscovery {
 }
 
 Describe 'Remove-ADOPSVariableGroup' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'VariableGroupName'; Mandatory = $true }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' { 0
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'VariableGroupName'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
+
     Context 'Removing variable group' {
         BeforeAll {
             Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -4,7 +4,14 @@ BeforeDiscovery {
 }
 
 InModuleScope -ModuleName ADOPS {
-    Describe 'Remove-ADOPSVariableGroup tests' {
+    Describe 'Remove-ADOPSVariableGroup' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'VariableGroupName'; Mandatory = $true }
+            @{ Name = 'Project'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
         Context 'Removing variable group' {
             BeforeAll {
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
@@ -82,27 +89,6 @@ InModuleScope -ModuleName ADOPS {
             }
             It 'should throw if VariableGroupName Name is invalid' {
                 { Remove-ADOPSVariableGroup -Organization $OrganizationName -Project $Project -VariableGroupName 'MissingVariableGroupName'} | Should -Throw
-            }
-        }
-
-        Context 'Parameters' {
-            It 'Should have parameter Organization' {
-                (Get-Command Remove-ADOPSVariableGroup).Parameters.Keys | Should -Contain 'Organization'
-            }
-            It 'Organization should not be required' {
-                (Get-Command Remove-ADOPSVariableGroup).Parameters['Organization'].Attributes.Mandatory | Should -Be $false
-            }
-            It 'Should have parameter Project' {
-                (Get-Command Remove-ADOPSVariableGroup).Parameters.Keys | Should -Contain 'Project'
-            }
-            It 'Project should be required' {
-                (Get-Command Remove-ADOPSVariableGroup).Parameters['Project'].Attributes.Mandatory | Should -Be $true
-            }
-            It 'Should have parameter VariableGroupName' {
-                (Get-Command Remove-ADOPSVariableGroup).Parameters.Keys | Should -Contain 'VariableGroupName'
-            }
-            It 'VariableGroupName should not be required' {
-                (Get-Command Remove-ADOPSVariableGroup).Parameters['VariableGroupName'].Attributes.Mandatory | Should -Be $true
             }
         }
     }

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -6,7 +6,7 @@ BeforeDiscovery {
 Describe 'Remove-ADOPSVariableGroup' {
     It 'Has parameter <_.Name>' -TestCases @(
         @{ Name = 'VariableGroupName'; Mandatory = $true }
-        @{ Name = 'Project'; }
+        @{ Name = 'Project'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
         Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type

--- a/Tests/Remove-ADOPSVariableGroup.tests.ps1
+++ b/Tests/Remove-ADOPSVariableGroup.tests.ps1
@@ -3,93 +3,91 @@ BeforeDiscovery {
     Initialize-TestSetup
 }
 
-InModuleScope -ModuleName ADOPS {
-    Describe 'Remove-ADOPSVariableGroup' {
-        It 'Has parameter <_.Name>' -TestCases @(
-            @{ Name = 'VariableGroupName'; Mandatory = $true }
-            @{ Name = 'Project'; }
-            @{ Name = 'Organization'; }
-        ) {
-            Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
-        }
-        Context 'Removing variable group' {
-            BeforeAll {
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
+Describe 'Remove-ADOPSVariableGroup' {
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'VariableGroupName'; Mandatory = $true }
+        @{ Name = 'Project'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Remove-ADOPSVariableGroup | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    }
+    Context 'Removing variable group' {
+        BeforeAll {
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
                     }
-                } -ParameterFilter { $OrganizationName -eq 'Organization' }
-                Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
-                    @{
-                        Header       = @{
-                            'Authorization' = 'Basic Base64=='
-                        }
-                        Organization = $OrganizationName
-                    }
+                    Organization = $OrganizationName
                 }
+            } -ParameterFilter { $OrganizationName -eq 'Organization' }
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
+                    }
+                    Organization = $OrganizationName
+                }
+            }
 
-                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    return ''
-                } -ParameterFilter { $method -eq 'Delete' }
-                Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    return [pscustomobject]@{
-                        'count' = 1
-                        'value' = @(
-                            @{
-                                id                             = 1
-                                type                           = 'Vsts'
-                                name                           = 'DummyGroup'
-                                description                    = 'DummyDescription'
-                                createdBy                      = @{
-                                    displayName = 'John Doe'
-                                    id          = '56c92d19-2fe9-49f8-96b4-922a0fea0e68'
-                                }
-                                createdOn                      = '2022-02-22 17:21:25'
-                                modifiedBy                     = @{
-                                    displayName = 'John Doe'
-                                    id          = '56c92d19-2fe9-49f8-96b4-922a0fea0e68'
-                                }
-                                modifiedOn                     = '2022-02-22 17:21:25'
-                                isShared                       = $false
-                                variableGroupProjectReferences = @(
-                                    @{
-                                        projectReference = ''
-                                        name             = 'DummyGroup'
-                                        description      = 'DummyDescription'
-                                    }
-                                )
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return ''
+            } -ParameterFilter { $method -eq 'Delete' }
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return [pscustomobject]@{
+                    'count' = 1
+                    'value' = @(
+                        @{
+                            id                             = 1
+                            type                           = 'Vsts'
+                            name                           = 'DummyGroup'
+                            description                    = 'DummyDescription'
+                            createdBy                      = @{
+                                displayName = 'John Doe'
+                                id          = '56c92d19-2fe9-49f8-96b4-922a0fea0e68'
                             }
-                        )
-                    }
-                } -ParameterFilter { $method -eq 'Get' }
-                Mock -CommandName Get-ADOPSProject -ModuleName ADOPS -MockWith {
-                    return [pscustomobject]@{
-                        id = (New-Guid).Guid
-                    }
+                            createdOn                      = '2022-02-22 17:21:25'
+                            modifiedBy                     = @{
+                                displayName = 'John Doe'
+                                id          = '56c92d19-2fe9-49f8-96b4-922a0fea0e68'
+                            }
+                            modifiedOn                     = '2022-02-22 17:21:25'
+                            isShared                       = $false
+                            variableGroupProjectReferences = @(
+                                @{
+                                    projectReference = ''
+                                    name             = 'DummyGroup'
+                                    description      = 'DummyDescription'
+                                }
+                            )
+                        }
+                    )
                 }
-
-                $OrganizationName = 'DummyOrg'
-                $Project = 'DummyProject'
-                $VariableGroupName = 'DummyGroup'
+            } -ParameterFilter { $method -eq 'Get' }
+            Mock -CommandName Get-ADOPSProject -ModuleName ADOPS -MockWith {
+                return [pscustomobject]@{
+                    id = (New-Guid).Guid
+                }
             }
 
-            It 'uses InvokeADOPSRestMethod two times' {
-                Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName
+            $OrganizationName = 'DummyOrg'
+            $Project = 'DummyProject'
+            $VariableGroupName = 'DummyGroup'
+        }
 
-                Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 2
-            }
-            It 'returns empty output after removing variable group' {
-                Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName | Should -BeNullOrEmpty
-            }
-            It 'should not throw with mandatory parameters' {
-                { Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName } | Should -Not -Throw
-            }
-            It 'should throw if VariableGroupName Name is invalid' {
-                { Remove-ADOPSVariableGroup -Organization $OrganizationName -Project $Project -VariableGroupName 'MissingVariableGroupName'} | Should -Throw
-            }
+        It 'uses InvokeADOPSRestMethod two times' {
+            Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName
+
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 2
+        }
+        It 'returns empty output after removing variable group' {
+            Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName | Should -BeNullOrEmpty
+        }
+        It 'should not throw with mandatory parameters' {
+            { Remove-ADOPSVariableGroup -Project $Project -VariableGroupName $VariableGroupName } | Should -Not -Throw
+        }
+        It 'should throw if VariableGroupName Name is invalid' {
+            { Remove-ADOPSVariableGroup -Organization $OrganizationName -Project $Project -VariableGroupName 'MissingVariableGroupName' } | Should -Throw
         }
     }
 }

--- a/Tests/Set-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Set-ADOPSElasticPool.Tests.ps1
@@ -4,12 +4,14 @@ BeforeDiscovery {
 }
 
 Describe "Set-ADOPSElasticPool" {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'PoolId'; Mandatory = $true }
-        @{ Name = 'ElasticPoolObject'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Set-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'PoolId'; Mandatory = $true }
+            @{ Name = 'ElasticPoolObject'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Set-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/Set-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Set-ADOPSElasticPool.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Set-ADOPSElasticPool" {
         @{ Name = 'ElasticPoolObject'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Set-ADOPSElasticPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Set-ADOPSElasticPool | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/Set-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Set-ADOPSElasticPool.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe "Set-ADOPSElasticPool" {
     Context "Function tests" {
@@ -16,7 +18,7 @@ Describe "Set-ADOPSElasticPool" {
         BeforeAll {
             Mock InvokeADOPSRestMethod -ModuleName ADOPS {
                 [PSCustomObject]@{
-                    elasticPool =                                                                                                             
+                    elasticPool =
                     @{
                         poolId               = 59
                         serviceEndpointId    = '44868479-e856-42bf-9a2b-74bb500d8e36'

--- a/Tests/Set-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Set-ADOPSElasticPool.Tests.ps1
@@ -4,14 +4,12 @@ BeforeDiscovery {
 }
 
 Describe "Set-ADOPSElasticPool" {
-    Context "Function tests" {
-        It "Function exists" {
-            { Get-Command -Name Set-ADOPSElasticPool -Module ADOPS -ErrorAction Stop } | Should -Not -Throw
-        }
-
-        It 'Has parameter <_>' -TestCases 'Organization', 'ElasticPoolObject', 'PoolId' {
-            (Get-Command -Name Set-ADOPSElasticPool).Parameters.Keys | Should -Contain $_
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'PoolId'; Mandatory = $true }
+        @{ Name = 'ElasticPoolObject'; Mandatory = $true }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Set-ADOPSElasticPool | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context "Function returns created elastic pool" {

--- a/Tests/Start-ADOPSPipeline.Tests.ps1
+++ b/Tests/Start-ADOPSPipeline.Tests.ps1
@@ -4,13 +4,15 @@ BeforeDiscovery {
 }
 
 Describe 'Start-ADOPSPipeline' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Name'; Mandatory = $true }
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'Branch'; }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Start-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Name'; Mandatory = $true }
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'Branch'; }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Start-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context 'Starting pipeline' {

--- a/Tests/Start-ADOPSPipeline.Tests.ps1
+++ b/Tests/Start-ADOPSPipeline.Tests.ps1
@@ -4,28 +4,13 @@ BeforeDiscovery {
 }
 
 Describe 'Start-ADOPSPipeline' {
-    Context 'Parameters' {
-        It 'Should have parameter Name' {
-            (Get-Command Start-ADOPSPipeline).Parameters.Keys | Should -Contain 'Name'
-        }
-        It 'Name should be mandatory' {
-            (Get-Command Start-ADOPSPipeline).Parameters['Name'].Attributes.Mandatory | Should -Be $true
-        }
-
-        It 'Should have parameter Project' {
-            (Get-Command Start-ADOPSPipeline).Parameters.Keys | Should -Contain 'Project'
-        }
-        It 'Project should be mandatory' {
-            (Get-Command Start-ADOPSPipeline).Parameters['Project'].Attributes.Mandatory | Should -Be $true
-        }
-
-        It 'Should have parameter Organization' {
-            (Get-Command Start-ADOPSPipeline).Parameters.Keys | Should -Contain 'Organization'
-        }
-
-        It 'Should have parameter Branch' {
-            (Get-Command Start-ADOPSPipeline).Parameters.Keys | Should -Contain 'Branch'
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Name'; Mandatory = $true }
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'Branch'; }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Start-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Starting pipeline' {

--- a/Tests/Start-ADOPSPipeline.Tests.ps1
+++ b/Tests/Start-ADOPSPipeline.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Start-ADOPSPipeline' {
         @{ Name = 'Branch'; }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Start-ADOPSPipeline | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Start-ADOPSPipeline | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Starting pipeline' {

--- a/Tests/Start-ADOPSPipeline.Tests.ps1
+++ b/Tests/Start-ADOPSPipeline.Tests.ps1
@@ -1,5 +1,7 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Start-ADOPSPipeline' {
     Context 'Parameters' {
@@ -47,7 +49,7 @@ Describe 'Start-ADOPSPipeline' {
                 }
 
                 Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
-                    '{"count":2,"value":[{"_links":{"self":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/1?revision=1"},"web":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_build/definition?definitionId=1"}},"url":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/1?revision=1","id":1,"revision":1,"name":"dummypipeline1","folder":"\\"},{"_links":{"self":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/3?revision=1"},"web":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_build/definition?definitionId=3"}},"url":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/3?revision=1","id":3,"revision":1,"name":"ummypipeline2","folder":"\\"}]}' | ConvertFrom-Json     
+                    '{"count":2,"value":[{"_links":{"self":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/1?revision=1"},"web":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_build/definition?definitionId=1"}},"url":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/1?revision=1","id":1,"revision":1,"name":"dummypipeline1","folder":"\\"},{"_links":{"self":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/3?revision=1"},"web":{"href":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_build/definition?definitionId=3"}},"url":"https://dev.azure.com/dummyorg/9ca5975f-7615-4f60-927d-d9222b095544/_apis/pipelines/3?revision=1","id":3,"revision":1,"name":"ummypipeline2","folder":"\\"}]}' | ConvertFrom-Json
                 } -ParameterFilter { $method -eq 'Get' }
 
                 Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {

--- a/Tests/Test-ADOPSYamlFile.Tests.ps1
+++ b/Tests/Test-ADOPSYamlFile.Tests.ps1
@@ -1,12 +1,14 @@
-Remove-Module ADOPS -ErrorAction SilentlyContinue
-Import-Module $PSScriptRoot\..\Source\ADOPS
+BeforeDiscovery {
+    . $PSScriptRoot\TestHelpers.ps1
+    Initialize-TestSetup
+}
 
 Describe 'Test-ADOPSYamlFile' {
     Context 'Parameters' {
         It 'Should have parameter Name' {
             (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'Organization'
         }
-        
+
         It 'Should have parameter Project' {
             (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'Project'
         }
@@ -20,7 +22,7 @@ Describe 'Test-ADOPSYamlFile' {
         It 'File should be mandatory' {
             (Get-Command Test-ADOPSYamlFile).Parameters['File'].Attributes.Mandatory | Should -Be $true
         }
-        
+
         It 'Should have parameter PipelineId' {
             (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'PipelineId'
         }
@@ -40,7 +42,7 @@ Describe 'Test-ADOPSYamlFile' {
                         Organization = 'DummyOrg'
                     }
                 } -ParameterFilter { $Organization -eq 'Organization' }
-                
+
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
                     @{
                         Header       = @{
@@ -71,7 +73,7 @@ inputs:
 testResultsFormat: NUnit
 testResultsFiles: |
     **\test*.xml
-failTaskOnFailedTests: false          
+failTaskOnFailedTests: false
 '@
                 }
             }
@@ -97,7 +99,7 @@ failTaskOnFailedTests: false
                         Organization = 'DummyOrg'
                     }
                 } -ParameterFilter { $Organization -eq 'Organization' }
-                
+
                 Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
                     @{
                         Header       = @{
@@ -128,7 +130,7 @@ inputs:
 testResultsFormat: NUnit
 testResultsFiles: |
     **\test*.xml
-failTaskOnFailedTests: false          
+failTaskOnFailedTests: false
 '@
                 }
 
@@ -142,7 +144,7 @@ failTaskOnFailedTests: false
                     $targetObject = $null
                     $errorRecord = New-Object Management.Automation.ErrorRecord $exception, $errorID, $errorCategory, $targetObject
                     $errorRecord.ErrorDetails = $errorDetails
-                
+
                     Throw $errorRecord
                 } -ParameterFilter { $method -eq 'post' -and $Uri -like '*/22/runs?*' }
             }
@@ -155,7 +157,7 @@ failTaskOnFailedTests: false
             Should -Invoke -CommandName InvokeADOPSRestMethod -Times 1 -Exactly -ModuleName ADOPS
             Should -Invoke -CommandName Get-Content -Times 1 -Exactly -ModuleName ADOPS
         }
-        
+
         It 'Should throw if file is not of type .yaml or .yml' {
             {Test-ADOPSYamlFile -Project 'DummyProj' -File 'c:\DummyFile.bad' -PipelineId 666} | Should -Throw
         }

--- a/Tests/Test-ADOPSYamlFile.Tests.ps1
+++ b/Tests/Test-ADOPSYamlFile.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Test-ADOPSYamlFile' {
         @{ Name = 'PipelineId'; Mandatory = $true }
         @{ Name = 'Organization'; }
     ) {
-        Get-Command -Name Test-ADOPSYamlFile | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        Get-Command -Name Test-ADOPSYamlFile | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Verifying invoke body' {

--- a/Tests/Test-ADOPSYamlFile.Tests.ps1
+++ b/Tests/Test-ADOPSYamlFile.Tests.ps1
@@ -4,13 +4,15 @@ BeforeDiscovery {
 }
 
 Describe 'Test-ADOPSYamlFile' {
-    It 'Has parameter <_.Name>' -TestCases @(
-        @{ Name = 'Project'; Mandatory = $true }
-        @{ Name = 'File'; Mandatory = $true }
-        @{ Name = 'PipelineId'; Mandatory = $true }
-        @{ Name = 'Organization'; }
-    ) {
-        Get-Command -Name Test-ADOPSYamlFile | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+    Context 'Parameter validation' {
+        It 'Has parameter <_.Name>' -TestCases @(
+            @{ Name = 'Project'; Mandatory = $true }
+            @{ Name = 'File'; Mandatory = $true }
+            @{ Name = 'PipelineId'; Mandatory = $true }
+            @{ Name = 'Organization'; }
+        ) {
+            Get-Command -Name Test-ADOPSYamlFile | Should -HaveParameterStrict $Name -Mandatory:([bool]$Mandatory) -Type $Type
+        }
     }
 
     Context 'Verifying invoke body' {

--- a/Tests/Test-ADOPSYamlFile.Tests.ps1
+++ b/Tests/Test-ADOPSYamlFile.Tests.ps1
@@ -4,31 +4,13 @@ BeforeDiscovery {
 }
 
 Describe 'Test-ADOPSYamlFile' {
-    Context 'Parameters' {
-        It 'Should have parameter Name' {
-            (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'Organization'
-        }
-
-        It 'Should have parameter Project' {
-            (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'Project'
-        }
-        It 'Project should be mandatory' {
-            (Get-Command Test-ADOPSYamlFile).Parameters['Project'].Attributes.Mandatory | Should -Be $true
-        }
-
-        It 'Should have parameter File' {
-            (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'File'
-        }
-        It 'File should be mandatory' {
-            (Get-Command Test-ADOPSYamlFile).Parameters['File'].Attributes.Mandatory | Should -Be $true
-        }
-
-        It 'Should have parameter PipelineId' {
-            (Get-Command Test-ADOPSYamlFile).Parameters.Keys | Should -Contain 'PipelineId'
-        }
-        It 'PipelineId should be mandatory' {
-            (Get-Command Test-ADOPSYamlFile).Parameters['PipelineId'].Attributes.Mandatory | Should -Be $true
-        }
+    It 'Has parameter <_.Name>' -TestCases @(
+        @{ Name = 'Project'; Mandatory = $true }
+        @{ Name = 'File'; Mandatory = $true }
+        @{ Name = 'PipelineId'; Mandatory = $true }
+        @{ Name = 'Organization'; }
+    ) {
+        Get-Command -Name Test-ADOPSYamlFile | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
     }
 
     Context 'Verifying invoke body' {

--- a/Tests/TestHelpers.ps1
+++ b/Tests/TestHelpers.ps1
@@ -1,0 +1,6 @@
+function Initialize-TestSetup {
+    [CmdletBinding()]
+    param ()
+    Remove-Module ADOPS -Force -ErrorAction Ignore
+    Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+}

--- a/Tests/TestHelpers.ps1
+++ b/Tests/TestHelpers.ps1
@@ -3,4 +3,5 @@ function Initialize-TestSetup {
     param ()
     Remove-Module ADOPS -Force -ErrorAction Ignore
     Import-Module $PSScriptRoot\..\Source\ADOPS -Force
+    Import-Module $PSScriptRoot\assertions\HaveParameterStrict.psm1 -DisableNameChecking -ErrorAction Stop
 }


### PR DESCRIPTION
# Contributing a Pull Request

Fixes #128

## Overview/Summary

#### Re-use the the same setup for all tests:
```powershell
function Initialize-TestSetup {
    [CmdletBinding()]
    param ()
    Remove-Module ADOPS -Force -ErrorAction Ignore
    Import-Module $PSScriptRoot\..\Source\ADOPS -Force
}
# ...
BeforeDiscovery {
    . $PSScriptRoot\TestHelpers.ps1
    Initialize-TestSetup
}
```

#### Test parameters in a concise way
```powershell
# Example
It 'Has parameter <_.Name>' -TestCases @(
    @{ Name = 'Username'; Mandatory = $true }
    @{ Name = 'PersonalAccessToken'; Mandatory = $true }
    @{ Name = 'Organization'; Mandatory = $true }
    @{ Name = 'Default'; Type = [switch] }
) {
    Get-Command -Name Connect-ADOPS | Should -HaveParameter $Name -Mandatory:([bool]$Mandatory) -Type $Type
}
```

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Verified build scripts work.
- [ ] Updated relevant and associated documentation.
