### PR TITLE
Updated documentation, Added fix for function and added support for managed identity in service connections.

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -13,7 +13,7 @@ jobs:
       run: Install-Module -Name Pester -Force
       shell: pwsh
     - name: Run tests
-      run: .\Tests\TestRunner.ps1 -TestResults -Verbosity Normal -ModuleLoadPath "$PSScriptRoot\Source\ADOPS.psm1" -CodeCoveragePath "$PSScriptRoot\Source\Public"
+      run: .\Tests\TestRunner.ps1 -TestResults -Verbosity Normal -ModuleLoadPath ".\Source\ADOPS.psm1" -CodeCoveragePath ".\Source\Public"
       shell: pwsh
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1

--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -13,7 +13,7 @@ jobs:
       run: Install-Module -Name Pester -Force
       shell: pwsh
     - name: Run tests
-      run: .\Tests\TestRunner.ps1 -TestResults -Verbosity Normal -CodeCoverage
+      run: .\Tests\TestRunner.ps1 -TestResults -Verbosity Normal -ModuleLoadPath "$PSScriptRoot\Source\ADOPS.psm1" -CodeCoveragePath "$PSScriptRoot\Source\Public"
       shell: pwsh
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action/composite@v1

--- a/Docs/Help/Get-ADOPSUser.md
+++ b/Docs/Help/Get-ADOPSUser.md
@@ -15,7 +15,7 @@ Fetch one or more users
 
 ### Default (Default)
 ```
-Get-ADOPSUser [-Organization <String>] [<CommonParameters>]
+Get-ADOPSUser [-Organization <String>] [-ContinuationToken <String>] [<CommonParameters>]
 ```
 
 ### Name
@@ -99,6 +99,21 @@ The organization to get users from.
 ```yaml
 Type: String
 Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContinuationToken
+Used to fetch the new page from the API.
+
+```yaml
+Type: String
+Parameter Sets: Default
 Aliases:
 
 Required: False

--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -12,9 +12,17 @@ Create an Azure DevOps Service Connection to Azure.
 
 ## SYNTAX
 
+### ServicePrincipal (Default)
 ```
-New-ADOPSServiceConnection [-TenantId] <String> [-SubscriptionName] <String> [-SubscriptionId] <String>
- [-Project] <String> [[-ConnectionName] <String>] [-ServicePrincipal] <PSCredential> [[-Organization] <String>]
+New-ADOPSServiceConnection [[-Organization] <String>] [-TenantId] <String> [-SubscriptionName] <String>
+ [-SubscriptionId] <String> [-Project] <String> [[-ConnectionName] <String>] [-ServicePrincipal] <PSCredential>
+ [<CommonParameters>]
+```
+
+### ManagedServiceIdentity
+```
+New-ADOPSServiceConnection [[-Organization] <String>] [-TenantId] <String> [-SubscriptionName] <String>
+ [-SubscriptionId] <String> [-Project] <String> [[-ConnectionName] <String>] [-ManagedIdentity]
  [<CommonParameters>]
 ```
 
@@ -86,11 +94,11 @@ Accept wildcard characters: False
 ```
 
 ### -ServicePrincipal
-Azure AD Service principal, Application (Client) ID and valid secret-
+Azure AD Service principal, Application (Client) ID and valid secret.
 
 ```yaml
 Type: PSCredential
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal
 Aliases:
 
 Required: True
@@ -140,6 +148,21 @@ Aliases:
 
 Required: True
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ManagedIdentity
+If a managed identity will be used for the connection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ManagedServiceIdentity
+Aliases:
+
+Required: True
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Docs/Help/Set-ADOPSServiceConnection.md
+++ b/Docs/Help/Set-ADOPSServiceConnection.md
@@ -1,0 +1,238 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Set-ADOPSServiceConnection
+
+## SYNOPSIS
+Allows update of a Azure DevOps Service Connection.
+
+## SYNTAX
+
+### ServicePrincipal (Default)
+```
+Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
+ -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
+ [-Description <String>] [-EndpointOperation <String>] -ServicePrincipal <PSCredential> [<CommonParameters>]
+```
+
+### ManagedServiceIdentity
+```
+Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
+ -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
+ [-Description <String>] [-EndpointOperation <String>] [-ManagedIdentity] [<CommonParameters>]
+```
+
+## DESCRIPTION
+If a managed identity will be used for the connection.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+$ApplicationName = 'demo-vmss-scaling-app' 
+$App = Get-AzADApplication -DisplayName $ApplicationName
+$AppCreds = New-AzADAppCredential -ApplicationId $App.AppId -EndDate (Get-Date).AddDays(7)
+$ServicePrincipal = Get-AzADServicePrincipal -ApplicationId $App.AppId
+
+$ServiceEndpoint = Get-ADOPSServiceConnection -Name "$ApplicationName-serviceconnection" -Project 'Azure'
+
+$ServiceConnectionParams = @{
+    TenantId = '34ca78c2-d872-455a-9977-88e161bd4ac0'
+    SubscriptionName = 'MySubscriptionName'
+    SubscriptionId = '8671f1d1-0bb1-4be0-b73c-6a8f3b354cf6'
+    ConnectionName = $ServiceEndpoint.name
+    Project = 'Azure'
+    Organization = 'MyOrganization'
+    ServiceEndpointId = $ServiceEndpoint.id
+    Description = 'Service Principal to manage scaling of the VMSS.'
+    ServicePrincipal= [pscredential]::new($ServicePrincipal.AppId,$(ConvertTo-SecureString -AsPlainText -Force $AppCreds.SecretText))
+}
+Set-ADOPSServiceConnection @ServiceConnectionParams
+```
+
+Updates the Service Connection called 'demo-vmss-scaling-app-serviceconnection' in the project called 'Azure' with a new secret.
+
+## PARAMETERS
+
+### -ConnectionName
+Name of Service Connection in Azure DevOps.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+The description field of the Service connection.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndpointOperation
+Undocumented.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ManagedIdentity
+If a managed identity is to be used by the Service Connection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ManagedServiceIdentity
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Organization
+Name of Azure DevOps organization.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+Name of the Azure DevOps project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServiceEndpointId
+The GUID of the Azure DevOps Service Endpoint.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ServicePrincipal
+Azure AD Service principal, Application (Client) ID and valid secret.
+
+```yaml
+Type: PSCredential
+Parameter Sets: ServicePrincipal
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SubscriptionId
+The subscription id that the service connection will be connected to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SubscriptionName
+The subscription name that the service connection will be connected to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TenantId
+The tenant id connected to your Azure AD and subscriptions.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Public/New-ADOPSElasticpool.ps1
+++ b/Source/Public/New-ADOPSElasticpool.ps1
@@ -28,9 +28,9 @@ function New-ADOPSElasticPool {
     }
 
     if ($PSBoundParameters.ContainsKey('ProjectId')) {
-        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?poolName=$PoolName`&authorizeAllPipelines=$AuthorizeAllPipelines`&autoProvisionProjectPools=$AutoProvisionProjectPools&projectId=$ProjectId&api-version=7.1-preview.1"
+        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?poolName=$PoolName`&authorizeAllPipelines=$AuthorizeAllPipelines`&autoProvisionProjectPools=$AutoProvisionProjectPools`&projectId=$ProjectId`&api-version=7.1-preview.1"
     } else {
-        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?poolName=$PoolName`&authorizeAllPipelines=$AuthorizeAllPipelines`&autoProvisionProjectPools=$AutoProvisionProjectPools&api-version=7.1-preview.1"
+        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?poolName=$PoolName`&authorizeAllPipelines=$AuthorizeAllPipelines`&autoProvisionProjectPools=$AutoProvisionProjectPools`&api-version=7.1-preview.1"
     }
 
     if ($ElasticPoolObject.gettype().name -eq 'String') {

--- a/Source/Public/New-ADOPSServiceConnection.ps1
+++ b/Source/Public/New-ADOPSServiceConnection.ps1
@@ -1,5 +1,5 @@
 function New-ADOPSServiceConnection {
-    [cmdletbinding()]
+    [cmdletbinding(DefaultParameterSetName='ServicePrincipal')]
     param(
         [Parameter()]
         [string]$Organization,
@@ -19,8 +19,11 @@ function New-ADOPSServiceConnection {
         [Parameter()]
         [string]$ConnectionName,
       
-        [Parameter(Mandatory)]
-        [pscredential]$ServicePrincipal
+        [Parameter(Mandatory,ParameterSetName = 'ServicePrincipal')]
+        [pscredential]$ServicePrincipal,
+
+        [Parameter(Mandatory,ParameterSetName = 'ManagedServiceIdentity')]
+        [switch]$ManagedIdentity
     )
 
     # Set organization
@@ -39,20 +42,9 @@ function New-ADOPSServiceConnection {
     if (-not $ConnectionName) {
         $ConnectionName = $SubscriptionName -replace " "
     }
-
-    # Create body for the API call
-    $Body = [ordered]@{
-        data                             = [ordered]@{
-            subscriptionId   = $SubscriptionId
-            subscriptionName = $SubscriptionName
-            environment      = "AzureCloud"
-            scopeLevel       = "Subscription"
-            creationMode     = "Manual"
-        }
-        name                             = ($SubscriptionName -replace " ")
-        type                             = "AzureRM"
-        url                              = "https://management.azure.com/"
-        authorization                    = [ordered]@{
+    
+    if ($PSCmdlet.ParameterSetName -eq 'ServicePrincipal') {
+        $authorization = [ordered]@{
             parameters = [ordered]@{
                 tenantid            = $TenantId
                 serviceprincipalid  = $ServicePrincipal.UserName
@@ -61,6 +53,37 @@ function New-ADOPSServiceConnection {
             }
             scheme     = "ServicePrincipal"
         }
+
+        $data = [ordered]@{
+            subscriptionId   = $SubscriptionId
+            subscriptionName = $SubscriptionName
+            environment      = "AzureCloud"
+            scopeLevel       = "Subscription"
+            creationMode     = "Manual"
+        }
+    } elseif ($PSCmdlet.ParameterSetName -eq 'ManagedServiceIdentity') {
+        $authorization = [ordered]@{
+            parameters = [ordered]@{
+                tenantid            = $TenantId
+            }
+            scheme     = "ManagedServiceIdentity"
+        }
+
+        $data = [ordered]@{
+            subscriptionId   = $SubscriptionId
+            subscriptionName = $SubscriptionName
+            environment      = "AzureCloud"
+            scopeLevel       = "Subscription"
+        }
+    }
+
+    # Create body for the API call
+    $Body = [ordered]@{
+        data                             =  $data
+        name                             = ($SubscriptionName -replace " ")
+        type                             = "AzureRM"
+        url                              = "https://management.azure.com/"
+        authorization                    = $authorization
         isShared                         = $false
         isReady                          = $true
         serviceEndpointProjectReferences = @(

--- a/Source/Public/Set-ADOPSServiceConnection.ps1
+++ b/Source/Public/Set-ADOPSServiceConnection.ps1
@@ -1,0 +1,129 @@
+function Set-ADOPSServiceConnection {
+    [CmdletBinding(DefaultParameterSetName = 'ServicePrincipal')]
+    param (
+        [Parameter()]
+        [string]$Organization,
+        
+        [Parameter(Mandatory)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory)]
+        [string]$SubscriptionName,
+
+        [Parameter(Mandatory)]
+        [string]$SubscriptionId,
+
+        [Parameter(Mandatory)]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [guid]$ServiceEndpointId,
+
+        [Parameter()]
+        [string]$ConnectionName,
+
+        [Parameter()]
+        [string]$Description,
+        
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$EndpointOperation,
+      
+        [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [pscredential]$ServicePrincipal,
+
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
+        [switch]$ManagedIdentity
+    )
+    
+    process {
+
+        # Set organization
+        if (-not [string]::IsNullOrEmpty($Organization)) {
+            $Org = GetADOPSHeader -Organization $Organization
+        }
+        else {
+            $Org = GetADOPSHeader
+            $Organization = $Org['Organization']
+        }
+
+        # Get ProjectId
+        $ProjectInfo = Get-ADOPSProject -Organization $Organization -Project $Project
+
+        # Set connection name if not set by parameter
+        if (-not $ConnectionName) {
+            $ConnectionName = $SubscriptionName -replace " "
+        }
+
+        switch ($PSCmdlet.ParameterSetName) {
+        
+            'ServicePrincipal' {
+                $authorization = [ordered]@{
+                    parameters = [ordered]@{
+                        tenantid            = $TenantId
+                        serviceprincipalid  = $ServicePrincipal.UserName
+                        authenticationType  = "spnKey"
+                        serviceprincipalkey = $ServicePrincipal.GetNetworkCredential().Password
+                    }
+                    scheme     = "ServicePrincipal"
+                }
+        
+                $data = [ordered]@{
+                    subscriptionId   = $SubscriptionId
+                    subscriptionName = $SubscriptionName
+                    environment      = "AzureCloud"
+                    scopeLevel       = "Subscription"
+                    creationMode     = "Manual"
+                }
+            }
+    
+            'ManagedServiceIdentity' {
+                $authorization = [ordered]@{
+                    parameters = [ordered]@{
+                        tenantid = $TenantId
+                    }
+                    scheme     = "ManagedServiceIdentity"
+                }
+            }
+        }
+
+        # Create body for the API call
+        $Body = [ordered]@{
+            authorization                    = $authorization
+            data                             = $data
+            description                      = "$Description"
+            id                               = $ServiceConnectionId
+            isReady                          = $true
+            isShared                         = $false
+            name                             = ($SubscriptionName -replace " ")
+            serviceEndpointProjectReferences = @(
+                [ordered]@{
+                    projectReference = [ordered]@{
+                        id   = $ProjectInfo.Id
+                        name = $Project
+                    }
+                    name             = $ConnectionName
+                }
+            )
+            type                             = "AzureRM"
+            url                              = "https://management.azure.com/"
+        } | ConvertTo-Json -Depth 10
+    
+        if ($PSBoundParameters.ContainsKey('EndpointOperation')) {
+            $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?operation=$EndpointOperation`&api-version=7.1-preview.4"
+        }
+        else {
+            $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?api-version=7.1-preview.4"
+        }
+        
+        $InvokeSplat = @{
+            Uri          = $URI
+            Method       = "PUT"
+            Body         = $Body
+            Organization = $Organization
+        }
+    
+        InvokeADOPSRestMethod @InvokeSplat
+
+    }
+}

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -44,6 +44,11 @@ Describe 'New-ADOPSServiceConnection' {
                 Name = 'ServicePrincipal'
                 Mandatory = $true
                 Type = 'pscredential'
+            },
+            @{
+                Name = 'ManagedIdentity'
+                Mandatory = $true
+                Type = 'switch'
             }
         )
     

--- a/Tests/Set-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Set-ADOPSServiceConnection.Tests.ps1
@@ -1,0 +1,117 @@
+param(
+    $PSM1 = "$PSScriptRoot\..\Source\ADOPS.psm1"
+)
+
+BeforeAll {
+    Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
+    Import-Module $PSM1 -Force
+}
+
+Describe 'Set-ADOPSServiceConnection' {
+    Context 'Parameters' {
+        $TestCases = @(
+            @{
+                Name = 'Organization'
+                Mandatory = $false
+                Type = 'string'
+            },
+            @{
+                Name = 'TenantId'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'SubscriptionName'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'SubscriptionId'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'Project'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'ConnectionName'
+                Mandatory = $false
+                Type = 'string'
+            },
+            @{
+                Name = 'ServicePrincipal'
+                Mandatory = $true
+                Type = 'pscredential'
+            },
+            @{
+                Name = 'ManagedIdentity'
+                Mandatory = $true
+                Type = 'switch'
+            },
+            @{
+                Name = 'ServiceEndpointId'
+                Mandatory = $true
+                Type = 'guid'
+            },@{
+                Name = 'EndpointOperation'
+                Mandatory = $false
+                Type = 'string'
+            }
+            
+        )
+    
+        It 'Should have parameter <_.Name>' -TestCases $TestCases  {
+            Get-Command Set-ADOPSServiceConnection | Should -HaveParameter $_.Name -Mandatory:$_.Mandatory -Type $_.Type
+        }
+    }
+
+    
+    Context "Functionality" {
+        BeforeAll {
+            Mock GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Organization = "myorg"
+                }
+            }
+            Mock GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -MockWith {
+                @{
+                    Organization = "anotherOrg"
+                }
+            }
+            
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
+
+            Mock -CommandName Get-ADOPSProject -ModuleName ADOPS -MockWith {
+                @{
+                    id = 'ProjectInfoId'
+                }
+            }
+        }
+        
+        BeforeEach {
+            $Splat = @{
+                Project = 'myproj' 
+                TenantId = 'AzureTennantId' 
+                SubscriptionName = 'AzureSubscriptionName' 
+                SubscriptionId = 'AzureSubscriptionId' 
+                ServiceEndpointId = '8bce170f-ac4e-4164-a7d7-6cbc8f69f6af'
+                ServicePrincipal = [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force))
+            }
+        }
+
+        It 'Should get organization from GetADOPSHeader when organization parameter is used' {
+            Set-ADOPSServiceConnection -Organization 'anotherorg' @Splat
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -Times 1 -Exactly
+        }
+
+        It 'Should validate organization using GetADOPSHeader when organization parameter is not used' {
+            Set-ADOPSServiceConnection @Splat
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'anotherorg' } -Times 0 -Exactly
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -Times 1 -Exactly
+        }
+
+    }
+}
+


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/ADOPS/ADOPS/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Overview/Summary

- Updated the help documentation for two existing functions.
- Updated the yaml for the Github pipeline to reflect changes to the TestRunner.ps1.
- Added a fix for New-ADOPSElasticpool (was missing an escape before the & sign).
- Added support for managed identity when creating service connections.
- Added new function (including help and tests) to update an existing Service Connection.
This new function allows us to update existing Service Connections with example new credentials, description etc.
Please note thought, that the Azure DevOps API does not set the description, seems like a bug across several API versions.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [X] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Verified build scripts work.
- [X] Updated relevant and associated documentation.
