### PR TITLE
Add check for overwriting current default

### DIFF
--- a/Source/Public/Connect-ADOPS.ps1
+++ b/Source/Public/Connect-ADOPS.ps1
@@ -22,9 +22,16 @@ function Connect-ADOPS {
         $ShouldBeDefault = $true
         $Script:ADOPSCredentials = @{}
     }
-    elseif ($default.IsPresent) {
-        $r = $script:ADOPSCredentials.Keys | Where-Object { $ADOPSCredentials[$_].Default -eq $true }
-        $ADOPSCredentials[$r].Default = $false
+    else {
+        $CurrentDefault = $script:ADOPSCredentials.Keys | Where-Object { $ADOPSCredentials[$_].Default -eq $true }
+        if ($CurrentDefault -eq $Organization) {
+            # If we are overwriting current default it should stay default regardless of -Default parameter.
+            $ShouldBeDefault = $true
+        }
+        elseif ($Default.IsPresent) {
+            # We are adding a new default, remove the current.  
+            $ADOPSCredentials[$CurrentDefault].Default = $false
+        }
     }
 
     $OrgData = @{

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -113,6 +113,24 @@ Describe 'Connect-ADOPS' {
         }
     }
 
+    Context 'Adding same connection again, not setting default' {
+        BeforeAll {
+            $DummyUser = 'DummyUserName'
+            $DummyPassword = 'DummyPassword'
+            $DummyOrg = 'DummyOrg'
+
+            Mock -CommandName InvokeADOPSRestMethod -MockWith {} -ModuleName ADOPS
+            Connect-ADOPS -Username $DummyUser -PersonalAccessToken $DummyPassword -Organization $DummyOrg
+        }
+        
+        It 'Should have set one default conenction' {
+            InModuleScope -ModuleName 'ADOPS' {
+                $r = $script:ADOPSCredentials.Keys | Where-Object {$ADOPSCredentials[$_].Default -eq $true}
+                $r.Count | Should -Be 1 -Because 'If this is the first connection we create we should always set it as default'
+            }
+        }
+    }
+
     Context 'Adding a second connection, not setting default' {
         BeforeAll {
             $DummyUser = 'DummyUserName2'


### PR DESCRIPTION
## Overview/Summary

Add a check in Connect-ADOPS to check if we are overwriting the current default entry.
If current default entry is being overwritten, keep it as default regardless of the value for -Default parameter.

Before this check was added, overwriting the default value without specifying -Default would set the default flag to false and we ended up without a default value. Then GetADOPSHeader would not be able to find any default entry and would throw an "Index operation failed" exception.

## This PR fixes/adds/changes/removes

1. Fix #136 - Overwriting current default token no longer fails when -Default is not set.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
