### PR TITLE
Added Get-ADOPSUsageData

### DIFF
--- a/Docs/Help/Get-ADOPSUsageData.md
+++ b/Docs/Help/Get-ADOPSUsageData.md
@@ -1,0 +1,98 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Get-ADOPSUsageData
+
+## SYNOPSIS
+Gets the usage data of your organization.
+
+## SYNTAX
+
+```
+Get-ADOPSUsageData [[-ProjectVisibility] <String>] [-SelfHosted] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This command gets usage data for you organization, such as
+
+- Currently running requests
+- Limits to your resource usage
+- Parallel sessions
+- Used minutes and hosts
+
+Note: This API is not public, and user data is dependent on current status, and is due to change with no notice.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-ADOPSUsageData
+```
+
+This command will return usage statistics and data for your public projects (default), and Microsoft hosted agents (default).
+
+### Example 2
+```powershell
+PS C:\> Get-ADOPSUsageData -ProjectVisibility Private -SelfHosted
+```
+
+This command will return usage statistics and data for your private projects, and self hosted agents.
+
+### Example 3
+```powershell
+PS C:\> Get-ADOPSUsageData -ProjectVisibility Public
+```
+
+This command will return usage statistics and data for your public projects (default), and Microsoft hosted agents (default).
+
+## PARAMETERS
+
+### -ProjectVisibility
+List usage data for private or public projects
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Private, Public
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SelfHosted
+If set, returns usage data for self hosted agents.
+If not set, returns usage data for Microsoft hosted agents.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Public/Get-ADOPSUsageData.ps1
+++ b/Source/Public/Get-ADOPSUsageData.ps1
@@ -1,0 +1,39 @@
+function Get-ADOPSUsageData {
+    param(
+        [Parameter()]
+        [ValidateSet('Private','Public')]
+        [string]$ProjectVisibility = 'Public',
+
+        [Parameter()]
+        [Switch]$SelfHosted,
+
+        [Parameter()]
+        [string]$Organization
+    )
+
+    if (-not [string]::IsNullOrEmpty($Organization)) {
+        $OrgInfo = GetADOPSHeader -Organization $Organization
+    }
+    else {
+        $OrgInfo = GetADOPSHeader
+        $Organization = $OrgInfo['Organization']
+    }
+
+    if ($SelfHosted.IsPresent) {
+        $Hosted = $false
+    }
+    else {
+        $Hosted = $true
+    }
+
+    $URI = "https://dev.azure.com/$Organization/_apis/distributedtask/resourceusage?parallelismTag=${ProjectVisibility}&poolIsHosted=${Hosted}&includeRunningRequests=true"
+    $Method = 'Get'
+    
+    $InvokeSplat = @{
+        Method       = $Method
+        Uri          = $URI
+        Organization = $Organization
+    }
+
+    InvokeADOPSRestMethod @InvokeSplat
+}

--- a/Tests/Get-ADOPSUsageData.Tests.ps1
+++ b/Tests/Get-ADOPSUsageData.Tests.ps1
@@ -1,0 +1,103 @@
+param(
+    $PSM1 = "$PSScriptRoot\..\Source\ADOPS.psm1"
+)
+
+BeforeAll {
+    Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
+    Import-Module $PSM1 -Force
+}
+
+Describe 'Get-ADOPSUsageData' {
+    Context 'Parameters' {
+        $TestCases = @(
+            @{
+                Name = 'Organization'
+                Mandatory = $false
+                Type = 'string'
+            },
+            @{
+                Name = 'ProjectVisibility'
+                Mandatory = $false
+                Type = 'string'
+            },
+            @{
+                Name = 'SelfHosted'
+                Mandatory = $false
+                Type = 'switch'
+            }
+        )
+    
+        It 'Should have parameter <_.Name>' -TestCases $TestCases  {
+            Get-Command Get-ADOPSUsageData | Should -HaveParameter $_.Name -Mandatory:$_.Mandatory -Type $_.Type
+        }
+    }
+
+    Context "Verifying request data" {
+        BeforeAll {
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS {}
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
+                    }
+                    Organization = 'DummyOrg'
+                }
+            } -ParameterFilter { $Organization -eq 'Organization' }
+            Mock -CommandName GetADOPSHeader -ModuleName ADOPS -MockWith {
+                @{
+                    Header       = @{
+                        'Authorization' = 'Basic Base64=='
+                    }
+                    Organization = 'DummyOrg'
+                }
+            }
+        }
+
+        It 'Should get organization from GetADOPSHeader when organization parameter is used' {
+            Get-ADOPSUsageData -Organization 'Organization'
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'Organization' } -Times 1 -Exactly
+        }
+        
+        It 'Should validate organization using GetADOPSHeader when organization parameter is not used' {
+            Get-ADOPSUsageData
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -ParameterFilter { $Organization -eq 'Organization' } -Times 0 -Exactly
+            Should -Invoke GetADOPSHeader -ModuleName ADOPS -Times 1 -Exactly
+        }
+
+        It 'Verifying request uri, ProjectVisibility:Private, SelfHosted:true' {
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS {
+                return $URI
+            }
+
+            $r = Get-ADOPSUsageData -ProjectVisibility Private -SelfHosted
+            $r | Should -Be 'https://dev.azure.com/DummyOrg/_apis/distributedtask/resourceusage?parallelismTag=Private&poolIsHosted=false&includeRunningRequests=true'
+        }
+
+        It 'Verifying request uri, ProjectVisibility:Public, SelfHosted:false' {
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS {
+                return $URI
+            }
+
+            $r = Get-ADOPSUsageData -ProjectVisibility Public
+            $r | Should -Be 'https://dev.azure.com/DummyOrg/_apis/distributedtask/resourceusage?parallelismTag=Public&poolIsHosted=true&includeRunningRequests=true'
+        }
+        
+        It 'Verifying request uri, no parameters' {
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS {
+                return $URI
+            }
+
+            $r = Get-ADOPSUsageData
+            $r | Should -Be 'https://dev.azure.com/DummyOrg/_apis/distributedtask/resourceusage?parallelismTag=Public&poolIsHosted=true&includeRunningRequests=true'
+        }
+
+        It 'Verifying method: Get' {
+            Mock InvokeADOPSRestMethod -ModuleName ADOPS {
+                return $Method
+            }
+            
+            $r = Get-ADOPSUsageData
+            $r | Should -Be 'Get'
+        }
+    }
+}


### PR DESCRIPTION
Totally unplanned, but I needed it to find stuff. Contains a lot more data than what the GUI will show you about your usage statistics found under `https://dev.azure.com/yourOrg/_settings/buildqueue`