### PR TITLE
Fix env admin

### DIFF
--- a/Source/Public/New-ADOPSEnvironment.ps1
+++ b/Source/Public/New-ADOPSEnvironment.ps1
@@ -54,7 +54,7 @@ function New-ADOPSEnvironment {
         $secUri = "https://dev.azure.com/$organization/_apis/securityroles/scopes/distributedtask.environmentreferencerole/roleassignments/resources/$($Environment.project.id)_$($Environment.id)?api-version=7.1-preview.1"
 
         if ([string]::IsNullOrEmpty($AdminGroup)) {
-            $AdmGroupPN = "[$organization]\Project Administrators"
+            $AdmGroupPN = "[$project]\Project Administrators"
         } 
         else {
             $AdmGroupPN = $AdminGroup

--- a/Tests/New-ADOPSEnvironment.Tests.ps1
+++ b/Tests/New-ADOPSEnvironment.Tests.ps1
@@ -46,7 +46,7 @@ Describe 'New-ADOPSEnvironment' {
             Mock -CommandName Get-ADOPSGroup -ModuleName ADOPS -MockWith {
                 @(
                     @{
-                        principalName = '[DummyOrg]\Project Administrators'
+                        principalName = '[DummyProj]\Project Administrators'
                         originId = 'ProjAdmOriginId'
                     },
                     @{


### PR DESCRIPTION
Change new environment admins to project instead of organization. Makes more sense.