### PR TITLE
Add RequiredModules to manifest

### DIFF
--- a/Source/ADOPS.psd1
+++ b/Source/ADOPS.psd1
@@ -51,7 +51,7 @@
     # ProcessorArchitecture = ''
 
     # Modules that must be imported into the global environment prior to importing this module
-    # RequiredModules = @()
+    RequiredModules = @(@{ModuleName='AzAuth'; ModuleVersion='2.2.2'; GUID='6efad2e7-3439-46fb-862d-eea4ebd67bc4'})
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()


### PR DESCRIPTION
## Overview/Summary

Add RequiredModules to manifest so AzAuth will be downloaded properly when installing from PSGallery

## This PR fixes/adds/changes/removes

1. Updated manifest to fix proper download of AzAuth from Gallery

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
