### PR TITLE
add workload identity federation support

### DIFF
--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -22,7 +22,15 @@ New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -Subscrip
 ### ManagedServiceIdentity
 ```
 New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
- -SubscriptionId <String> -Project <String> [-ConnectionName <String>] [-ManagedIdentity] [<CommonParameters>]
+ -SubscriptionId <String> -Project <String> [-ConnectionName <String>] -ServicePrincipal <PSCredential>
+ [-ManagedIdentity] [<CommonParameters>]
+```
+
+### WorkloadIdentityFederation
+```
+New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
+ -SubscriptionId <String> -Project <String> [-ConnectionName <String>] [-WorkloadIdentityFederation]
+ -AzureScope <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,7 +53,55 @@ New-ADOPSServiceConnection @Params
 
 Creates an Azure DevOps Service Connection to an Azure subscription using an existing Service Principal object in Azure AD.
 
+### Example 2
+```powershell
+$Params = @{
+    TenantId = "32238a3e-4aae-4a9d-a3be-5c2912088b9b"
+    SubscriptionName = "My Subscription"
+    SubscriptionId = "34dacce0-5332-4b27-a804-4352202aca27"
+    ServicePrincipal = Get-Credential
+    Project = "My DevOps Project"
+    ConnectionName = "My Service Connection Name"
+    ManagedIdentity = $true
+}
+New-ADOPSServiceConnection @Params
+```
+
+Creates an Azure DevOps Service Connection to an Azure subscription using a managed service principal in Azure AD.
+
+### Example 3
+```powershell
+$Params = @{
+    TenantId = "32238a3e-4aae-4a9d-a3be-5c2912088b9b"
+    SubscriptionName = "My Subscription"
+    SubscriptionId = "34dacce0-5332-4b27-a804-4352202aca27"
+    Project = "My DevOps Project"
+    ConnectionName = "My Service Connection Name"
+    WorkloadIdentityFederation = $true
+    AzureScope = (Get-AzResourceGroup -Name MyAzureRG).ResourceId
+}
+New-ADOPSServiceConnection @Params
+```
+
+Creates an Azure DevOps Service Connection to an Azure resource group using workload identity federation (OAuth) and automatically creating an app registration in Azure AD.
+
 ## PARAMETERS
+
+### -AzureScope
+resource group ID where the app registration will be granted contributor access.
+/subscriptions/4ba9b4a1-dc0d-4ec8-adaf-061771ccd1da/resourceGroups/MyAzureRG
+
+```yaml
+Type: String
+Parameter Sets: WorkloadIdentityFederation
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ConnectionName
 Name of Service Connection in Azure DevOps.
@@ -112,7 +168,7 @@ Azure AD Service principal, Application (Client) ID and valid secret.
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServicePrincipal
+Parameter Sets: ServicePrincipal, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -158,6 +214,21 @@ The tenant id connected to your Azure AD and subscriptions.
 ```yaml
 Type: String
 Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkloadIdentityFederation
+If Workload identity federation will be used for the connection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: WorkloadIdentityFederation
 Aliases:
 
 Required: True

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -49,6 +49,16 @@ Describe 'New-ADOPSServiceConnection' {
                 Name = 'ManagedIdentity'
                 Mandatory = $true
                 Type = 'switch'
+            },
+            @{
+                Name = 'WorkloadIdentityFederation'
+                Mandatory = $true
+                Type = 'switch'
+            },
+            @{
+                Name = 'AzureScope'
+                Mandatory = $true
+                Type = 'string'
             }
         )
     
@@ -77,30 +87,49 @@ Describe 'New-ADOPSServiceConnection' {
                 TenantId = 'AzureTennantId' 
                 SubscriptionName = 'AzureSubscriptionName' 
                 SubscriptionId = 'AzureSubscriptionId' 
-                ServicePrincipal = [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force))
             }
         }
 
         It 'Should not get organization from GetADOPSDefaultOrganization when organization parameter is used' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             New-ADOPSServiceConnection -Organization 'anotherorg' @Splat
             Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 0 -Exactly
         }
 
         It 'Should get organization using GetADOPSDefaultOrganization when organization parameter is not used' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             New-ADOPSServiceConnection @Splat
             Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 1 -Exactly
         }
 
         It 'Verifying URI is correct' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $URI}
             $r = New-ADOPSServiceConnection @Splat
-            $r | Should -Be 'https://dev.azure.com/myorg/myproj/_apis/serviceendpoint/endpoints?api-version=7.1-preview.4'
+            $r | Should -Be 'https://dev.azure.com/myorg/myproj/_apis/serviceendpoint/endpoints?api-version=7.2-preview.4'
         }
 
-        It 'Verifying body is correct' {
+        It 'Verifying body is correct - ServicePrincipal' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body}
             $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
             $r | Should -Be '{"data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Manual"},"name":"AzureSubscriptionName","type":"AzureRM","url":"https://management.azure.com/","authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","authenticationType":"spnKey","serviceprincipalkey":"PassWord"},"scheme":"ServicePrincipal"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+        }
+
+        It 'Verifying body is correct - ManagedServiceIdentity' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
+            $Splat.Add('ManagedIdentity', $true)
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body}
+            $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
+            $r | Should -Be '{"data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription"},"name":"AzureSubscriptionName","type":"AzureRM","url":"https://management.azure.com/","authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","serviceprincipalkey":"PassWord"},"scheme":"ManagedServiceIdentity"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+        }
+
+        It 'Verifying body is correct - WorkloadIdentityFederation' {
+            $Splat.Add('WorkloadIdentityFederation', $true)
+            $Splat.Add('AzureScope', 'Azure/Scope')
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body}
+            $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
+            $r | Should -Be '{"data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Automatic"},"name":"AzureSubscriptionName","type":"AzureRM","url":"https://management.azure.com/","authorization":{"parameters":{"tenantid":"AzureTennantId","scope":"Azure/Scope"},"scheme":"WorkloadIdentityFederation"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
     }
 }


### PR DESCRIPTION
This PR closes #191 by adding support for workload identity federation when creating Azure service connections.
Included is also tests, and updated help docs.

Default parameter set is still ServicePrincipal so no major bump is needed for now. This should change in the future.