### PR TITLE
Workaround to return the correct users

### DIFF
--- a/Source/Public/Get-ADOPSUser.ps1
+++ b/Source/Public/Get-ADOPSUser.ps1
@@ -41,6 +41,9 @@ function Get-ADOPSUser {
         $Uri = "https://vsaex.dev.azure.com/$Organization/_apis/UserEntitlements?`$filter=name eq '$Name'&`$orderBy=name Ascending&api-version=7.1-preview.3"
         $Method = 'GET'
         $Users = (InvokeADOPSRestMethod -Uri $Uri -Method $Method).members.user
+        if ($null -eq $Users) {
+            Get-ADOPSUser | Where-Object -Property displayName -eq $Name
+        }
         Write-Output $Users
     }
     elseif ($PSCmdlet.ParameterSetName -eq 'Descriptor') {


### PR DESCRIPTION
This pr closes #183 by adding a workaround for the vsaex endpoints.
Since the vssps endpoints do not support queriess / search we try first using the "better" API. If no results are returned (if you for example search for a build account) it will recursevly search and filter from the 'displayName' property of the vssps/Graph API. This makes the query slower, but gives the correct results.