### PR TITLE
Simplify Set-ADOPSGitPermission input

### DIFF
--- a/Docs/Help/Set-ADOPSGitPermission.md
+++ b/Docs/Help/Set-ADOPSGitPermission.md
@@ -13,7 +13,7 @@ Sets git ref permissions on a Azure DevOps git repo
 ## SYNTAX
 
 ```
-Set-ADOPSGitPermission [[-Organization] <String>] [-ProjectId] <String> [-RepositoryId] <String>
+Set-ADOPSGitPermission [[-Organization] <String>] [-Project] <String> [-Repository] <String>
  [-Descriptor] <String> [[-Allow] <AccessLevels[]>] [[-Deny] <AccessLevels[]>] [<CommonParameters>]
 ```
 
@@ -151,14 +151,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ProjectId
-Project id where the repository is located.
-Can be found using the `Get-ADOPSProject` command
+### -Project
+Project ID or Project Name where the repo is located.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: ProjectId
 
 Required: True
 Position: 1
@@ -167,14 +166,13 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RepositoryId
-Repository id of the git repo in Azure DevOps.
-Can be found using the `Get-ADOPSRepository` command
+### -Repository
+Repository ID or Repository Name to set access to.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: RepositoryId
 
 Required: True
 Position: 2

--- a/Source/Public/Set-ADOPSGitPermission.ps1
+++ b/Source/Public/Set-ADOPSGitPermission.ps1
@@ -6,12 +6,12 @@ function Set-ADOPSGitPermission {
         [string]$Organization,
         
         [Parameter(Mandatory)]
-        [ValidatePAttern('^[a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}$', ErrorMessage = 'ProjectId must be in GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)')]
-        [string]$ProjectId,
+        [Alias('ProjectId')]
+        [string]$Project,
         
         [Parameter(Mandatory)]
-        [ValidatePAttern('^[a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}$', ErrorMessage = 'ProjectId must be in GUID format (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)')]
-        [string]$RepositoryId,
+        [Alias('RepositoryId')]
+        [string]$Repository,
         
         [Parameter(Mandatory)]
         [ValidatePattern('^[a-z]{3,5}\.[a-zA-Z0-9]{40,}$', ErrorMessage = 'Descriptor must be in the descriptor format')]
@@ -26,6 +26,21 @@ function Set-ADOPSGitPermission {
         [AccessLevels[]]$Deny
     )
     
+    # Allow input of names instead of IDs
+    if ($Project -notmatch '^[a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}$') {
+        $Project = Get-ADOPSProject -Name $Project | Select-Object -ExpandProperty id
+        if ($null -eq $Project) {
+            throw "No project named $Project found."
+        }
+    }
+    if ($Repository -notmatch '^[a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}$') {
+        $Repository = Get-ADOPSRepository -Repository $Repository -Project $Project
+        if ($null -eq $Repository) {
+            throw "No repository named $Repository in project $Project found."
+        }
+    }
+
+
     if (-not $Allow -and -not $Deny) {
         Write-Verbose 'No allow or deny rules set'
     }

--- a/Source/Public/Set-ADOPSGitPermission.ps1
+++ b/Source/Public/Set-ADOPSGitPermission.ps1
@@ -66,7 +66,7 @@ function Set-ADOPSGitPermission {
         $SubjectDescriptor = (InvokeADOPSRestMethod -Uri "https://vssps.dev.azure.com/$Organization/_apis/identities?subjectDescriptors=$Descriptor&queryMembership=None&api-version=7.1-preview.1" -Method Get).value.descriptor
 
         $Body = [ordered]@{
-            token                = "repov2/$Projectid/$RepositoryId"
+            token                = "repov2/$Project/$Repository"
             merge                = $true
             accessControlEntries = @(
                 [ordered]@{

--- a/Tests/Set-ADOPSGitPermission.Tests.ps1
+++ b/Tests/Set-ADOPSGitPermission.Tests.ps1
@@ -16,12 +16,12 @@ Describe 'Set-ADOPSGitPermission' {
                 Type = 'string'
             },
             @{
-                Name = 'RepositoryId'
+                Name = 'Repository'
                 Mandatory = $true
                 Type = 'string'
             },
             @{
-                Name = 'ProjectId'
+                Name = 'Project'
                 Mandatory = $true
                 Type = 'string'
             },
@@ -70,8 +70,8 @@ Describe 'Set-ADOPSGitPermission' {
 
         It 'If organization is given, it should not call GetADOPSDefaultOrganization' {
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' 
                 Organization = 'DummyOrg'
                 Allow = 'Administer'
@@ -82,8 +82,8 @@ Describe 'Set-ADOPSGitPermission' {
 
         It 'If organization is not given, it should call GetADOPSDefaultOrganization' {
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'Administer'
             }
@@ -93,34 +93,30 @@ Describe 'Set-ADOPSGitPermission' {
 
         It 'If neither allow or deny is set, it should not do anything' {
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
             }
             Set-ADOPSGitPermission @s | Should -BeNullOrEmpty
         }
 
         It 'Should throw if user descriptor is not formated like a descriptor, too short' {
-            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'aad.NotADescriptorLength' -ProjectId 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' -RepositoryId '11111111-1111-1111-1111-111111111111'} | Should -Throw
+            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'aad.NotADescriptorLength' -Project 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' -Repository '11111111-1111-1111-1111-111111111111'} | Should -Throw
         }
 
         It 'Should throw if Group descriptor is not formated like a descriptor, too short' {
-            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'aadgp.NotADescriptorLength' -ProjectId 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' -RepositoryId '11111111-1111-1111-1111-111111111111'} | Should -Throw
+            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'aadgp.NotADescriptorLength' -Project 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' -Repository '11111111-1111-1111-1111-111111111111'} | Should -Throw
         }
 
         It 'Should throw if user descriptor is not formated like a descriptor, no first three letters' {
-            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'NotADescriptor' -ProjectId 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' -RepositoryId '11111111-1111-1111-1111-111111111111'} | Should -Throw
-        }
-
-        It 'Should throw if projectID is not in correct format' {
-            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' -ProjectId 'projectId' -RepositoryId '11111111-1111-1111-1111-111111111111'} | Should -Throw
+            {Set-ADOPSGitPermission -Allow Administer -Descriptor 'NotADescriptor' -Project 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' -Repository '11111111-1111-1111-1111-111111111111'} | Should -Throw
         }
 
         It 'Verifying tokenPath' {
             $Expected = 'repov2/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/11111111-1111-1111-1111-111111111111'
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'Administer'
             }
@@ -141,8 +137,8 @@ Describe 'Set-ADOPSGitPermission' {
 
             $Expected = 'Microsoft.IdentityModel.Claims.ClaimsIdentity;aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\user@domain.onmicrosoft.com'
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'Administer'
             }
@@ -153,8 +149,8 @@ Describe 'Set-ADOPSGitPermission' {
         It 'Set allow to the expected int value, no input' {
             $Expected = 0
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Deny = 'Administer'
             }
@@ -165,8 +161,8 @@ Describe 'Set-ADOPSGitPermission' {
         It 'Set deny to the expected int value, no input' {
             $Expected = 0
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'Administer'
             }
@@ -177,8 +173,8 @@ Describe 'Set-ADOPSGitPermission' {
         It 'Set allow to the expected int value, one input' {
             $Expected = 256
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'CreateRepository'
             }
@@ -189,8 +185,8 @@ Describe 'Set-ADOPSGitPermission' {
         It 'Set deny to the expected int value, one input' {
             $Expected = 256
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Deny = 'CreateRepository'
             }
@@ -201,8 +197,8 @@ Describe 'Set-ADOPSGitPermission' {
         It 'Set allow to the expected int value, multiple inputs' {
             $Expected = 1032
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'RenameRepository','ForcePush'
             }
@@ -213,8 +209,8 @@ Describe 'Set-ADOPSGitPermission' {
         It 'Set deny to the expected int value, multiple inputs' {
             $Expected = 1032
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Deny = 'RenameRepository','ForcePush'
             }
@@ -235,8 +231,8 @@ Describe 'Set-ADOPSGitPermission' {
 
             $Expected = '{"token":"repov2/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/11111111-1111-1111-1111-111111111111","merge":true,"accessControlEntries":[{"allow":1,"deny":0,"descriptor":"Microsoft.IdentityModel.Claims.ClaimsIdentity;aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\\user@domain.onmicrosoft.com"}]}'
             $s = @{
-                ProjectId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
-                RepositoryId = '11111111-1111-1111-1111-111111111111' 
+                Project = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' 
+                Repository = '11111111-1111-1111-1111-111111111111' 
                 Descriptor = 'aad.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
                 Allow = 'Administer'
             }


### PR DESCRIPTION
This pr closes #184  by allowing input of repository and project names instead of id.
Aliases added for old parameter names to prevent compatibility issues.