### PR TITLE
Allow organization url to be passed.

### DIFF
--- a/Docs/Help/Connect-ADOPS.md
+++ b/Docs/Help/Connect-ADOPS.md
@@ -111,7 +111,7 @@ Accept wildcard characters: False
 
 ### -Organization
 
-Name of the Azure DevOps organization.
+Name of the Azure DevOps organization or url of the organization like `https://dev.azure.com/MyOrg/`
 
 ```yaml
 Type: String

--- a/Source/Public/Connect-ADOPS.ps1
+++ b/Source/Public/Connect-ADOPS.ps1
@@ -66,7 +66,7 @@ function Connect-ADOPS {
     $Orgs = GetADOPSOrganizationAccess -AccountId $Me.publicAlias -Token $Token
 
     if ($Organization -match "https://dev.azure.com/*") {
-        $Organization = $Organization -replace "https://dev.azure.com/", ""
+        $Organization = ($Organization -split "/")[3]
     }
     
     if ($Organization -notin $Orgs) {

--- a/Source/Public/Connect-ADOPS.ps1
+++ b/Source/Public/Connect-ADOPS.ps1
@@ -65,7 +65,7 @@ function Connect-ADOPS {
     # Get available orgs
     $Orgs = GetADOPSOrganizationAccess -AccountId $Me.publicAlias -Token $Token
 
-    if ($Organization -match "https://dev.azure.com/*") {
+    if ($Organization -like "https://dev.azure.com/*") {
         $Organization = ($Organization -split "/")[3]
     }
     

--- a/Source/Public/Connect-ADOPS.ps1
+++ b/Source/Public/Connect-ADOPS.ps1
@@ -64,6 +64,10 @@ function Connect-ADOPS {
 
     # Get available orgs
     $Orgs = GetADOPSOrganizationAccess -AccountId $Me.publicAlias -Token $Token
+
+    if ($Organization -match "https://dev.azure.com/*") {
+        $Organization = $Organization -replace "https://dev.azure.com/", ""
+    }
     
     if ($Organization -notin $Orgs) {
         throw "The connected account does not have access to the organization '$Organization'. Organizations available: $($Orgs -join ",")`nAre you connected to the correct tennant? $TokenTenantId"

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -82,6 +82,12 @@ Describe 'Connect-ADOPS' {
                 }
             }
         }
+        
+        It 'Should parse organization from Azure DevOps Service url' {
+            Mock -ModuleName ADOPS SetADOPSConfigFile
+            Connect-ADOPS -OAuthToken 'MyTokenGoesHere' -Organization 'https://dev.azure.com/MyOrg1/'
+            Should -Invoke SetADOPSConfigFile -Times 1 -Exactly -ModuleName ADOPS -ParameterFilter { $ConfigObject['Default']['Organization'] -eq "MyOrg1" }
+        }
 
         It 'Should not call Get-AzToken when OAuthToken is provided' {
             Connect-ADOPS -OAuthToken 'MyTokenGoesHere' -Organization 'MyOrg1'

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -84,9 +84,13 @@ Describe 'Connect-ADOPS' {
         }
         
         It 'Should parse organization from Azure DevOps Service url' {
+            Mock -ModuleName ADOPS GetADOPSConfigFile -MockWith {
+                '{"Default":{"TenantId":"NotSpecified","Organization":"MyOrg2","Identity":"dummyuser@domain.com"}}' | ConvertFrom-Json -AsHashtable
+            }
             Mock -ModuleName ADOPS SetADOPSConfigFile
             Connect-ADOPS -OAuthToken 'MyTokenGoesHere' -Organization 'https://dev.azure.com/MyOrg1/'
             Should -Invoke SetADOPSConfigFile -Times 1 -Exactly -ModuleName ADOPS -ParameterFilter { $ConfigObject['Default']['Organization'] -eq "MyOrg1" }
+            Should -Invoke GetADOPSConfigFile -Times 1 -Exactly -ModuleName ADOPS
         }
 
         It 'Should not call Get-AzToken when OAuthToken is provided' {


### PR DESCRIPTION
## Overview/Summary

Feature: Ability to pass organization  url as organization parameter. This would allow the ability to pass pipeline variable `System.CollectionUri`.

## This PR fixes/adds/changes/removes

1. Organization on connect will strip URL to get the Organization Name

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Verified build scripts work.
- [X] Updated relevant and associated documentation.
