### PR TITLE
Fixing `Get-ADOPSElasticPool -PoolId`

### DIFF
--- a/Source/Public/Get-ADOPSElasticPool.ps1
+++ b/Source/Public/Get-ADOPSElasticPool.ps1
@@ -14,7 +14,7 @@ function Get-ADOPSElasticPool {
     }
 
     if ($PSBoundParameters.ContainsKey('PoolId')) {
-        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools/$PoolId?api-version=7.1-preview.1"
+        $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools/$PoolId`?api-version=7.1-preview.1"
     } else {
         $Uri = "https://dev.azure.com/$Organization/_apis/distributedtask/elasticpools?api-version=7.1-preview.1"
     }

--- a/Tests/Get-ADOPSElasticPool.Tests.ps1
+++ b/Tests/Get-ADOPSElasticPool.Tests.ps1
@@ -98,6 +98,11 @@ Describe "Get-ADOPSElasticPool" {
             Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter { $Uri -eq 'https://dev.azure.com/DummyOrg/_apis/distributedtask/elasticpools?api-version=7.1-preview.1' }
         }
 
+        It 'Calls InvokeADOPSRestMethod when id is used' {
+            Get-ADOPSElasticPool -PoolId 123
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter { $Uri -eq 'https://dev.azure.com/DummyOrg/_apis/distributedtask/elasticpools/123?api-version=7.1-preview.1' }
+        }
+
         It 'Can handle single elastic pool responses from API' {
             Mock InvokeADOPSRestMethod -ModuleName ADOPS {
                 [PSCustomObject]@{


### PR DESCRIPTION
## Overview/Summary

Bug fix for `Get-ADOPSElasticPool -PoolId` url interpolation.

## This PR fixes/adds/changes/removes

1. Fixed `PoolId` interpolation on `Get-ADOPSElasticPool`

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Verified build scripts work.
- [X] Updated relevant and associated documentation.
