### PR TITLE
Add -SkipVerification to support using System.AccessToken in AzDO

### DIFF
--- a/Docs/Help/Connect-ADOPS.md
+++ b/Docs/Help/Connect-ADOPS.md
@@ -15,17 +15,20 @@ Establish a connection to Azure DevOps.
 
 ### Interactive (Default)
 ```
-Connect-ADOPS -Organization <String> [-TenantId <String>] [-Interactive] [<CommonParameters>]
+Connect-ADOPS -Organization <String> [-TenantId <String>] [-SkipVerification] [-Interactive]
+ [<CommonParameters>]
 ```
 
 ### OAuthToken
 ```
-Connect-ADOPS -Organization <String> [-TenantId <String>] -OAuthToken <String> [<CommonParameters>]
+Connect-ADOPS -Organization <String> [-TenantId <String>] [-SkipVerification] -OAuthToken <String>
+ [<CommonParameters>]
 ```
 
 ### ManagedIdentity
 ```
-Connect-ADOPS -Organization <String> [-TenantId <String>] [-ManagedIdentity] [<CommonParameters>]
+Connect-ADOPS -Organization <String> [-TenantId <String>] [-SkipVerification] [-ManagedIdentity]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -54,10 +57,10 @@ Connect to an Azure DevOps organization using a managed identity, specifying the
 ### Example 3
 
 ```powershell
-Connect-ADOPS -OAuthToken $AccessToken -Organization 'ADOPS'
+Connect-ADOPS -OAuthToken $AccessToken -Organization 'ADOPS' -SkipVerification
 ```
 
-Connect to an Azure DevOps organization using an existing access token.
+Connect to an Azure DevOps organization using an existing access token. It will not verify that the token has access to the selected organization, and may result in failed API calls.
 
 ## PARAMETERS
 
@@ -119,6 +122,23 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipVerification
+
+This switch is necessary to set when using System.AccessToken as OAuth token in Azure DevOps.
+This will bypass the access verification. If this flag is set we will not check if the provided account can access the selected organization, and there may be access errors when API calls are made.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/Source/Public/Connect-ADOPS.ps1
+++ b/Source/Public/Connect-ADOPS.ps1
@@ -10,6 +10,11 @@ function Connect-ADOPS {
         [Parameter(ParameterSetName = 'ManagedIdentity')]
         [Parameter(ParameterSetName = 'OAuthToken')]
         [string]$TenantId,
+        
+        [Parameter(ParameterSetName = 'Interactive')]
+        [Parameter(ParameterSetName = 'ManagedIdentity')]
+        [Parameter(ParameterSetName = 'OAuthToken')]
+        [switch]$SkipVerification,
 
         [Parameter(ParameterSetName = 'Interactive')]
         [switch]$Interactive,
@@ -59,18 +64,24 @@ function Connect-ADOPS {
         }
     }
 
-    # Get User context
-    $Me = InvokeADOPSRestMethod -Method GET -Token $Token -Uri 'https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1-preview.3'
-
-    # Get available orgs
-    $Orgs = GetADOPSOrganizationAccess -AccountId $Me.publicAlias -Token $Token
-
     if ($Organization -like "https://dev.azure.com/*") {
         $Organization = ($Organization -split "/")[3]
     }
     
-    if ($Organization -notin $Orgs) {
-        throw "The connected account does not have access to the organization '$Organization'. Organizations available: $($Orgs -join ",")`nAre you connected to the correct tennant? $TokenTenantId"
+    if (-not $PSBoundParameters.ContainsKey('SkipVerification')) {
+        # Get User context
+        $Me = InvokeADOPSRestMethod -Method GET -Token $Token -Uri 'https://app.vssps.visualstudio.com/_apis/profile/profiles/me?api-version=7.1-preview.3'
+    
+        # Get available orgs
+        $Orgs = GetADOPSOrganizationAccess -AccountId $Me.publicAlias -Token $Token
+    
+        if ($Organization -notin $Orgs) {
+            throw "The connected account does not have access to the organization '$Organization'. Organizations available: $($Orgs -join ",")`nAre you connected to the correct tennant? $TokenTenantId"
+        }
+    }
+    else {
+        Write-Verbose 'Skipping organization access verification.'
+        $Me = @{ id = 'unverified' }
     }
 
     # If user provided a token, we have not parsed the JWT for the email/id

--- a/Tests/Connect-ADOPS.Tests.ps1
+++ b/Tests/Connect-ADOPS.Tests.ps1
@@ -28,6 +28,11 @@ Describe 'Connect-ADOPS' {
                 Type      = 'string'
             },
             @{
+                Name      = 'SkipVerification'
+                Mandatory = $false
+                Type      = 'switch'
+            },
+            @{
                 Name      = 'Interactive'
                 Mandatory = $false
                 Type      = 'System.Management.Automation.SwitchParameter'
@@ -104,6 +109,12 @@ Describe 'Connect-ADOPS' {
 
         It 'Should throw if token does not have access to provided organization' {
             { Connect-ADOPS -OAuthToken 'MyTokenGoesHere' -Organization 'MyOrg3' } | Should -Throw
+        }
+
+        It 'If -SkipVerification is set, should not verify organization' {
+            { Connect-ADOPS -OAuthToken 'MyTokenGoesHere' -Organization 'MyOrg1' -SkipVerification } | Should -Not -Throw
+            Should -Invoke InvokeADOPSRestMethod -Times 0 -Exactly -ModuleName ADOPS
+            Should -Invoke GetADOPSOrganizationAccess -Times 0 -Exactly -ModuleName ADOPS
         }
     }
 }


### PR DESCRIPTION
## Overview/Summary

This PR adds -SkipVerification to Connect-ADOPS in order to fully support the use of Azure DevOps System.AccessToken.
See discussion #202 
