### PR TITLE
Get-ADOPSPipeline -Name $Name -Revision $Revision

### DIFF
--- a/Docs/Help/Get-ADOPSPipeline.md
+++ b/Docs/Help/Get-ADOPSPipeline.md
@@ -34,6 +34,14 @@ Get pipeline with name $Name from $Project.
 ### Example 2
 
 ```powershell
+PS C:\> Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $Name -Revision $Revision
+```
+
+Get pipeline with name $Name and specific $Revision from $Project
+
+### Example 2
+
+```powershell
 PS C:\> Get-ADOPSPipeline -Organization $OrganizationName -Project $Project
 ```
 
@@ -65,9 +73,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Revision
+
+Revision of the pipeline. Omit to get latest.
+
+```yaml
+Type: int
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Organization
 
-The organization to get pipeline/s from.
+The organization to get pipelines from.
 
 ```yaml
 Type: String
@@ -75,7 +99,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 2
+Position: 3
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -83,7 +107,7 @@ Accept wildcard characters: False
 
 ### -Project
 
-The project to get pilepine/s from.
+The project to get pipelines from.
 
 ```yaml
 Type: String
@@ -91,7 +115,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/Tests/Get-ADOPSPipeline.Tests.ps1
+++ b/Tests/Get-ADOPSPipeline.Tests.ps1
@@ -24,6 +24,11 @@ Describe 'Get-ADOPSPipeline' {
                 Name = 'name'
                 Mandatory = $false
                 Type = 'string'
+            },
+            @{
+                Name = 'revision'
+                Mandatory = $false
+                Type = 'int'
             }
         )
 
@@ -96,6 +101,14 @@ Describe 'Get-ADOPSPipeline' {
         It 'uses InvokeADOPSRestMethod two times' {
             Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName
             Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 2
+        }
+        It 'Calls InvokeADOPSRestMethod when revision is from pipeline lookup' {
+            Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter { $Uri -eq 'https://dev.azure.com/DummyOrg/DummyProject/_apis/pipelines/10?api-version=7.1-preview.1&pipelineVersion=1' }
+        }
+        It 'Calls InvokeADOPSRestMethod when revision is from input' {
+            Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName -Revision 2
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter { $Uri -eq 'https://dev.azure.com/DummyOrg/DummyProject/_apis/pipelines/10?api-version=7.1-preview.1&pipelineVersion=2' }
         }
         It 'returns output after getting pipeline' {
             Get-ADOPSPipeline -Organization $OrganizationName -Project $Project -Name $PipeName | Should -BeOfType [pscustomobject] -Because 'InvokeADOPSRestMethod should convert the json to pscustomobject'


### PR DESCRIPTION
## Overview/Summary

Adding the ability to retrieve a pipeline at a specific revision.

## This PR fixes/adds/changes/removes

1. Adds optional overload parameter `Revision` to `Get-ADOPSPipeline`. If omitted the revision from the pipeline id lookup is used. 
2. [Possible Behavior Change, likely desired] Previously the Pipeline URL was used from the pipeline name lookup but **would always pull latest** because the query parameter `revision` is invalid for `/_api/pipelines/`, instead `pipelineVersion` is used and `revision` on the get definition api. Since we are crafting the URL we are using the correct query parameter for revision AND scoping it to a specific api version where before it was likely the latest API always. 

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [X] Performed testing and provided evidence.
- [X] Verified build scripts work.
- [X] Updated relevant and associated documentation.
