### PR TITLE
ADOPSProjectRetentionSettings - Needs feedback

### DIFF
--- a/Source/Public/Get-ADOPSProjectRetentionSettings.ps1
+++ b/Source/Public/Get-ADOPSProjectRetentionSettings.ps1
@@ -1,0 +1,30 @@
+function Get-ADOPSProjectRetentionSettings {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Project
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+
+    $Uri = "https://dev.azure.com/$Organization/$Project/_apis/build/retention?api-version=7.2-preview.1"
+    $Settings = InvokeADOPSRestMethod -Uri $Uri -Method Get
+
+    $ResponseHasRetainRunsPerProtectedBranch = $Settings | Get-Member -MemberType NoteProperty | Where-Object Name -eq "retainRunsPerProtectedBranch"
+    if ($ResponseHasRetainRunsPerProtectedBranch -and ($null -eq $Settings.retainRunsPerProtectedBranch)) {
+        $Settings.retainRunsPerProtectedBranch = [pscustomobject]@{
+            min   = [long]0
+            max   = [long]50
+            value = $null
+        }
+    }
+
+    Write-Output $Settings
+}

--- a/Source/Public/Set-ADOPSProjectRetentionSettings.ps1
+++ b/Source/Public/Set-ADOPSProjectRetentionSettings.ps1
@@ -1,0 +1,47 @@
+function Set-ADOPSProjectRetentionSettings {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]$Organization,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Project,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        $Values
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+
+    $Uri = "https://dev.azure.com/$Organization/$Project/_apis/build/retention?api-version=7.2-preview.1"
+    $Body = $Values | ConvertTo-Json
+    Write-Debug $Body
+    $Settings = InvokeADOPSRestMethod -Uri $Uri -Method Patch -Body $Body
+    Write-Debug ($Settings | ConvertTo-Json)
+
+    $ValuesHasRetainRunsPerProtectedBranch = $Values | Get-Member -MemberType NoteProperty | Where-Object Name -eq "retainRunsPerProtectedBranch"
+    $ResponseHasRetainRunsPerProtectedBranch = $Settings | Get-Member -MemberType NoteProperty | Where-Object Name -eq "retainRunsPerProtectedBranch"
+    if ($ResponseHasRetainRunsPerProtectedBranch -and ($null -eq $Settings.retainRunsPerProtectedBranch)) {
+        if ($ValuesHasRetainRunsPerProtectedBranch) {
+            $settings.retainRunsPerProtectedBranch = [pscustomobject]@{
+                min   = [long] 0
+                max   = [long] 50
+                value = $Values.retainRunsPerProtectedBranch.value
+            }
+        }
+        else {
+            $settings.retainRunsPerProtectedBranch = [pscustomobject]@{
+                min   = [long] 0
+                max   = [long] 50
+                value = $null
+            }
+        }
+    }
+    
+    Write-Output $Settings
+}


### PR DESCRIPTION
## Overview/Summary

```ps1
$RetentionSettings = Get-ADOPSProjectRetentionSettings -Project 'MyProject'
$RetentionSettings
$RetentionSettings.retainRunsPerProtectedBranch

$RetentionSettings.purgeArtifacts.value = 60
$RetentionSettings.purgePullRequestRuns.value = 30
$RetentionSettings.purgeRuns.value = 731

# _settings/setting ux field "Number of recent runs to retain per pipeline" 
# when updated uses @{ runsToRetainPerProtectedBranch = @{ value = $value } }
#     but the API uses @{ retainRunsPerProtectedBranch     = @{ value = $value } }
# Perhaps this naming is the reason why its never returned on the API?
# $RetentionSettings.retainRunsPerProtectedBranch = @{
#     value = 30
# }

# To mitigate I construct the customobject and set value to $null unless it was passed in during set
$RetentionSettings.retainRunsPerProtectedBranch.value = 30

Set-ADOPSProjectRetentionSettings -Project 'MyProject' -Values $RetentionSettings
```

## This PR fixes/adds/changes/removes

1. TODO

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Verified build scripts work.
- [ ] Updated relevant and associated documentation.
