### PR TITLE
`New-ADOPSServiceConnection` / `Set-ADOPSServiceConnection` for any service endpoint type

### DIFF
--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -172,7 +172,7 @@ Accept wildcard characters: False
 ```
 
 ### -Description
-{{ Fill Description Description }}
+Description of Service Connection in Azure DevOps.
 
 ```yaml
 Type: String

--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -15,27 +15,27 @@ Create an Azure DevOps Service Connection to Azure.
 ### ServicePrincipal (Default)
 ```
 New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
- -SubscriptionId <String> -Project <String> [-ConnectionName <String>] -ServicePrincipal <PSCredential>
- [<CommonParameters>]
+ -SubscriptionId <String> -Project <String> [-ConnectionName <String>] [-Description <String>]
+ -ServicePrincipal <PSCredential> [<CommonParameters>]
 ```
 
 ### ManagedServiceIdentity
 ```
 New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
- -SubscriptionId <String> -Project <String> [-ConnectionName <String>] -ServicePrincipal <PSCredential>
- [-ManagedIdentity] [<CommonParameters>]
+ -SubscriptionId <String> -Project <String> [-ConnectionName <String>] [-Description <String>]
+ -ServicePrincipal <PSCredential> [-ManagedIdentity] [<CommonParameters>]
 ```
 
 ### WorkloadIdentityFederation
 ```
 New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
- -SubscriptionId <String> -Project <String> [-ConnectionName <String>] [-WorkloadIdentityFederation]
- -AzureScope <String> [<CommonParameters>]
+ -SubscriptionId <String> -Project <String> [-ConnectionName <String>] [-Description <String>]
+ [-WorkloadIdentityFederation] -AzureScope <String> [<CommonParameters>]
 ```
 
 ### GenericServiceConnection
 ```
-New-ADOPSServiceConnection [-Organization <String>] -ConnectionData <object>
+New-ADOPSServiceConnection [-Organization <String>] -ConnectionData <Object> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -158,6 +158,21 @@ Accept wildcard characters: False
 
 ### -ConnectionName
 Name of Service Connection in Azure DevOps.
+
+```yaml
+Type: String
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Description
+{{ Fill Description Description }}
 
 ```yaml
 Type: String

--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -33,8 +33,15 @@ New-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -Subscrip
  -AzureScope <String> [<CommonParameters>]
 ```
 
+### GenericServiceConnection
+```
+New-ADOPSServiceConnection [-Organization <String>] -ConnectionData <object>
+```
+
 ## DESCRIPTION
 Creates an Azure DevOps Service Connection to Azure subscription using an existing Service Principal. Assign the necessary permissions in Azure for the service principal.
+
+With the parameter set `GenericServiceConnection` any service connection type can be created.
 
 ## EXAMPLES
 
@@ -83,7 +90,28 @@ $Params = @{
 New-ADOPSServiceConnection @Params
 ```
 
-Creates an Azure DevOps Service Connection to an Azure resource group using workload identity federation (OAuth) and automatically creating an app registration in Azure AD.
+### Example 4
+```powershell
+$ConnectionData = [ordered]@{
+    type          = "dockerregistry"
+    name          = "Service Connection Name"
+    description   = "Service Connection Description"
+    authorization = [ordered]@{
+        paramaters = [ordered]@{
+            registry = "dockerregistry.local"
+            username = "pipeline"
+            password = "supersecretpassword"
+            email    = "admin@dockerregistry.local"
+        }
+    }
+    isSshared     = $false
+    isReady       = $true
+    owner         = "Library"
+}
+New-ADOPSServiceConnection -ConnectionData $ConnectionData
+```
+
+Creates an Azure DevOps Service Connection to a Docker Registry.
 
 ## PARAMETERS
 
@@ -103,12 +131,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ConnectionData
+New Service Connection request data.
+
+```yaml
+Type: Object
+Parameter Sets: GenericServiceConnection
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ConnectionName
 Name of Service Connection in Azure DevOps.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: False
@@ -153,7 +196,7 @@ Name of Azure DevOps project.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -183,7 +226,7 @@ The subscription id that the service connection will be connected to.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -198,7 +241,7 @@ The subscription name that the service connection will be connected to.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -213,7 +256,7 @@ The tenant id connected to your Azure AD and subscriptions.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True

--- a/Docs/Help/New-ADOPSServiceConnection.md
+++ b/Docs/Help/New-ADOPSServiceConnection.md
@@ -93,10 +93,11 @@ New-ADOPSServiceConnection @Params
 ### Example 4
 ```powershell
 $ConnectionData = [ordered]@{
-    type          = "dockerregistry"
-    name          = "Service Connection Name"
-    description   = "Service Connection Description"
-    authorization = [ordered]@{
+    type                             = "dockerregistry"
+    name                             = "Service Connection Name"
+    description                      = "Service Connection Description"
+    authorization                    = [ordered]@{
+        scheme     = "UsernamePassword"
         paramaters = [ordered]@{
             registry = "dockerregistry.local"
             username = "pipeline"
@@ -104,9 +105,18 @@ $ConnectionData = [ordered]@{
             email    = "admin@dockerregistry.local"
         }
     }
-    isSshared     = $false
-    isReady       = $true
-    owner         = "Library"
+    isSshared                        = $false
+    isReady                          = $true
+    owner                            = "Library"
+    serviceEndpointProjectReferences = @(
+        [ordered]@{
+            projectReference = [ordered]@{
+                id   = "de6a3035-0146-4ae2-81c1-68596d187cf4"
+                name = "My DevOps Project"
+            }
+            name             = "Service Connection Name"
+        }
+    )
 }
 New-ADOPSServiceConnection -ConnectionData $ConnectionData
 ```

--- a/Docs/Help/Set-ADOPSServiceConnection.md
+++ b/Docs/Help/Set-ADOPSServiceConnection.md
@@ -16,18 +16,36 @@ Allows update of a Azure DevOps Service Connection.
 ```
 Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
  -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
- [-Description <String>] [-EndpointOperation <String>] -ServicePrincipal <PSCredential> [<CommonParameters>]
+ [-Description <String>] [-EndpointOperation <String>] -ServicePrincipal <PSCredential>
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### GenericServiceConnection
+```
+Set-ADOPSServiceConnection [-Organization <String>] -ConnectionData <Object> [-EndpointOperation <String>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### WorkloadIdentityFederation
+```
+Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
+ -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
+ [-Description <String>] [-EndpointOperation <String>] [-WorkloadIdentityFederation] -AzureScope <String>
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ManagedServiceIdentity
 ```
 Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
  -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
- [-Description <String>] [-EndpointOperation <String>] [-ManagedIdentity] [<CommonParameters>]
+ [-Description <String>] [-EndpointOperation <String>] -ServicePrincipal <PSCredential> [-ManagedIdentity]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-If a managed identity will be used for the connection.
+Updates an Azure DevOps Service Connection to Azure subscription using an existing Service Principal. Assign the necessary permissions in Azure for the service principal.
+
+With the parameter set `GenericServiceConnection` any service connection type can be modified.
 
 ## EXAMPLES
 
@@ -58,12 +76,43 @@ Updates the Service Connection called 'demo-vmss-scaling-app-serviceconnection' 
 
 ## PARAMETERS
 
+### -AzureScope
+resource group ID where the app registration will be granted contributor access.
+/subscriptions/4ba9b4a1-dc0d-4ec8-adaf-061771ccd1da/resourceGroups/MyAzureRG
+
+```yaml
+Type: String
+Parameter Sets: WorkloadIdentityFederation
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectionData
+New Service Connection request data.
+
+```yaml
+Type: Object
+Parameter Sets: GenericServiceConnection
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ConnectionName
 Name of Service Connection in Azure DevOps.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: False
@@ -78,7 +127,7 @@ The description field of the Service connection.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: False
@@ -138,7 +187,7 @@ Name of the Azure DevOps project.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -153,7 +202,7 @@ The GUID of the Azure DevOps Service Endpoint.
 
 ```yaml
 Type: Guid
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -168,7 +217,7 @@ Azure AD Service principal, Application (Client) ID and valid secret.
 
 ```yaml
 Type: PSCredential
-Parameter Sets: ServicePrincipal
+Parameter Sets: ServicePrincipal, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -183,7 +232,7 @@ The subscription id that the service connection will be connected to.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -198,7 +247,7 @@ The subscription name that the service connection will be connected to.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
 Aliases:
 
 Required: True
@@ -213,7 +262,22 @@ The tenant id connected to your Azure AD and subscriptions.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ServicePrincipal, WorkloadIdentityFederation, ManagedServiceIdentity
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkloadIdentityFederation
+If Workload identity federation will be used for the connection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: WorkloadIdentityFederation
 Aliases:
 
 Required: True

--- a/Docs/Help/Set-ADOPSServiceConnection.md
+++ b/Docs/Help/Set-ADOPSServiceConnection.md
@@ -17,13 +17,13 @@ Allows update of a Azure DevOps Service Connection.
 Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
  -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
  [-Description <String>] [-EndpointOperation <String>] -ServicePrincipal <PSCredential>
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### GenericServiceConnection
 ```
 Set-ADOPSServiceConnection [-Organization <String>] -ConnectionData <Object> [-EndpointOperation <String>]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### WorkloadIdentityFederation
@@ -31,7 +31,7 @@ Set-ADOPSServiceConnection [-Organization <String>] -ConnectionData <Object> [-E
 Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
  -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
  [-Description <String>] [-EndpointOperation <String>] [-WorkloadIdentityFederation] -AzureScope <String>
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ### ManagedServiceIdentity
@@ -39,7 +39,7 @@ Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -Subscrip
 Set-ADOPSServiceConnection [-Organization <String>] -TenantId <String> -SubscriptionName <String>
  -SubscriptionId <String> -Project <String> -ServiceEndpointId <Guid> [-ConnectionName <String>]
  [-Description <String>] [-EndpointOperation <String>] -ServicePrincipal <PSCredential> [-ManagedIdentity]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/Source/Private/NewAzureServiceConnection.ps1
+++ b/Source/Private/NewAzureServiceConnection.ps1
@@ -1,0 +1,126 @@
+function NewAzureServiceConnection {
+    param(
+        [string]$Organization,
+
+        [string]$TenantId,
+
+        [string]$SubscriptionName,
+
+        [string]$SubscriptionId,
+
+        [string]$Project,
+
+        [string]$ConnectionName,
+      
+        [pscredential]$ServicePrincipal,
+
+        [switch]$ManagedIdentity,
+
+        [switch]$WorkloadIdentityFederation,
+
+        [string]$AzureScope
+    )
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+
+    # Get ProjectId
+    $ProjectInfo = Get-ADOPSProject -Organization $Organization -Project $Project
+
+    # Set connection name if not set by parameter
+    if (-not $ConnectionName) {
+        $ConnectionName = $SubscriptionName -replace ' '
+    }
+
+    switch ($PSCmdlet.ParameterSetName) {
+
+        'ServicePrincipal' {
+            $authorization = [ordered]@{
+                parameters = [ordered]@{
+                    tenantid            = $TenantId
+                    serviceprincipalid  = $ServicePrincipal.UserName
+                    authenticationType  = 'spnKey'
+                    serviceprincipalkey = $ServicePrincipal.GetNetworkCredential().Password
+                }
+                scheme     = 'ServicePrincipal'
+            }
+
+            $data = [ordered]@{
+                subscriptionId   = $SubscriptionId
+                subscriptionName = $SubscriptionName
+                environment      = 'AzureCloud'
+                scopeLevel       = 'Subscription'
+                creationMode     = 'Manual'
+            }
+        }
+
+        'ManagedServiceIdentity' {
+            $authorization = [ordered]@{
+                parameters = [ordered]@{
+                    tenantid            = $TenantId
+                    serviceprincipalid  = $ServicePrincipal.UserName
+                    serviceprincipalkey = $ServicePrincipal.GetNetworkCredential().Password
+                }
+                scheme     = 'ManagedServiceIdentity'
+            }
+
+            $data = [ordered]@{
+                subscriptionId   = $SubscriptionId
+                subscriptionName = $SubscriptionName
+                environment      = 'AzureCloud'
+                scopeLevel       = 'Subscription'
+            }
+        }
+
+        'WorkloadIdentityFederation' {
+            $authorization = [ordered]@{
+                parameters = [ordered]@{
+                    tenantid = $TenantId
+                    scope    = $AzureScope
+                }
+                scheme     = 'WorkloadIdentityFederation'
+            }
+
+            $data = [ordered]@{
+                subscriptionId   = $SubscriptionId
+                subscriptionName = $SubscriptionName
+                environment      = 'AzureCloud'
+                scopeLevel       = 'Subscription'
+                creationMode     = 'Automatic'
+            }
+        }
+    }
+
+    # Create body for the API call
+    $Body = [ordered]@{
+        data                             = $data
+        name                             = ($SubscriptionName -replace ' ')
+        type                             = 'AzureRM'
+        url                              = 'https://management.azure.com/'
+        authorization                    = $authorization
+        isShared                         = $false
+        isReady                          = $true
+        serviceEndpointProjectReferences = @(
+            [ordered]@{
+                projectReference = [ordered]@{
+                    id   = $ProjectInfo.Id
+                    name = $Project
+                }
+                name             = $ConnectionName
+            }
+        )
+    } | ConvertTo-Json -Depth 10
+
+    # Run function
+    $URI = "https://dev.azure.com/$Organization/$Project/_apis/serviceendpoint/endpoints?api-version=7.2-preview.4"
+    $InvokeSplat = @{
+        Uri    = $URI
+        Method = 'POST'
+        Body   = $Body
+    }
+
+    $Response = InvokeADOPSRestMethod @InvokeSplat
+
+    return $Response
+}

--- a/Source/Private/NewAzureServiceConnection.ps1
+++ b/Source/Private/NewAzureServiceConnection.ps1
@@ -11,6 +11,8 @@ function NewAzureServiceConnection {
         [string]$Project,
 
         [string]$ConnectionName,
+
+        [string]$Description,
       
         [pscredential]$ServicePrincipal,
 
@@ -94,10 +96,11 @@ function NewAzureServiceConnection {
 
     # Create body for the API call
     $Body = [ordered]@{
-        data                             = $data
         name                             = ($SubscriptionName -replace ' ')
+        description                      = "$Description"
         type                             = 'AzureRM'
         url                              = 'https://management.azure.com/'
+        data                             = $data
         authorization                    = $authorization
         isShared                         = $false
         isReady                          = $true

--- a/Source/Private/NewGenericServiceConnection.ps1
+++ b/Source/Private/NewGenericServiceConnection.ps1
@@ -1,0 +1,23 @@
+function NewGenericServiceConnection {
+    param (
+        [string]$Organization,
+
+        $ConnectionData
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+    
+    $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints?api-version=7.2-preview.4"
+    $InvokeSplat = @{
+        Uri    = $URI
+        Method = 'POST'
+        Body   = $ConnectionData | ConvertTo-Json -Depth 10
+    }
+
+    $Response = InvokeADOPSRestMethod @InvokeSplat
+
+    return $Response
+}

--- a/Source/Private/SetAzureServiceConnection.ps1
+++ b/Source/Private/SetAzureServiceConnection.ps1
@@ -1,0 +1,105 @@
+function SewAzureServiceConnection {
+    param(
+        [string]$Organization,
+
+        [string]$TenantId,
+
+        [string]$SubscriptionName,
+
+        [string]$SubscriptionId,
+
+        [string]$Project,
+
+        [string]$ConnectionName,
+      
+        [pscredential]$ServicePrincipal,
+
+        [switch]$ManagedIdentity,
+
+        [switch]$WorkloadIdentityFederation,
+
+        [string]$AzureScope
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+    
+    # Get ProjectId
+    $ProjectInfo = Get-ADOPSProject -Organization $Organization -Project $Project
+    
+    # Set connection name if not set by parameter
+    if (-not $ConnectionName) {
+        $ConnectionName = $SubscriptionName -replace " "
+    }
+    
+    switch ($PSCmdlet.ParameterSetName) {
+            
+        'ServicePrincipal' {
+            $authorization = [ordered]@{
+                parameters = [ordered]@{
+                    tenantid            = $TenantId
+                    serviceprincipalid  = $ServicePrincipal.UserName
+                    authenticationType  = "spnKey"
+                    serviceprincipalkey = $ServicePrincipal.GetNetworkCredential().Password
+                }
+                scheme     = "ServicePrincipal"
+            }
+            
+            $data = [ordered]@{
+                subscriptionId   = $SubscriptionId
+                subscriptionName = $SubscriptionName
+                environment      = "AzureCloud"
+                scopeLevel       = "Subscription"
+                creationMode     = "Manual"
+            }
+        }
+        
+        'ManagedServiceIdentity' {
+            $authorization = [ordered]@{
+                parameters = [ordered]@{
+                    tenantid = $TenantId
+                }
+                scheme     = "ManagedServiceIdentity"
+            }
+        }
+    }
+    
+    # Create body for the API call
+    $Body = [ordered]@{
+        authorization                    = $authorization
+        data                             = $data
+        description                      = "$Description"
+        id                               = $ServiceConnectionId
+        isReady                          = $true
+        isShared                         = $false
+        name                             = ($SubscriptionName -replace " ")
+        serviceEndpointProjectReferences = @(
+            [ordered]@{
+                projectReference = [ordered]@{
+                    id   = $ProjectInfo.Id
+                    name = $Project
+                }
+                name             = $ConnectionName
+            }
+        )
+        type                             = "AzureRM"
+        url                              = "https://management.azure.com/"
+    } | ConvertTo-Json -Depth 10
+        
+    if ($PSBoundParameters.ContainsKey('EndpointOperation')) {
+        $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?operation=$EndpointOperation`&api-version=7.1-preview.4"
+    }
+    else {
+        $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?api-version=7.1-preview.4"
+    }
+            
+    $InvokeSplat = @{
+        Uri    = $URI
+        Method = "PUT"
+        Body   = $Body
+    }
+        
+    InvokeADOPSRestMethod @InvokeSplat
+}

--- a/Source/Private/SetAzureServiceConnection.ps1
+++ b/Source/Private/SetAzureServiceConnection.ps1
@@ -1,23 +1,17 @@
-function SewAzureServiceConnection {
+function SetAzureServiceConnection {
     param(
         [string]$Organization,
-
         [string]$TenantId,
-
         [string]$SubscriptionName,
-
         [string]$SubscriptionId,
-
         [string]$Project,
-
+        [guid]$ServiceEndpointId,
         [string]$ConnectionName,
-      
+        [string]$Description,
+        [string]$EndpointOperation,
         [pscredential]$ServicePrincipal,
-
         [switch]$ManagedIdentity,
-
         [switch]$WorkloadIdentityFederation,
-
         [string]$AzureScope
     )
 
@@ -95,7 +89,7 @@ function SewAzureServiceConnection {
     
     # Create body for the API call
     $Body = [ordered]@{
-        id                               = $ServiceConnectionId
+        id                               = $ServiceEndpointId
         name                             = ($SubscriptionName -replace " ")
         description                      = "$Description"
         type                             = "AzureRM"

--- a/Source/Private/SetGenericServiceConnection.ps1
+++ b/Source/Private/SetGenericServiceConnection.ps1
@@ -1,0 +1,38 @@
+function SetGenericServiceConnection {
+    param (
+        [string]$Organization,
+
+        $ConnectionData,
+
+        $EndpointOperation
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+
+    if (-Not ($ConnectionData.ID)) {
+        throw "ConnectionData must contain a valid ID"
+    }
+    else {
+        $ServiceEndpointId = $ConnectionData.ID
+    }
+    
+    if ($PSBoundParameters.ContainsKey('EndpointOperation')) {
+        $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?operation=$EndpointOperation`&api-version=7.1-preview.4"
+    }
+    else {
+        $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?api-version=7.1-preview.4"
+    }
+
+    $InvokeSplat = @{
+        Uri    = $URI
+        Method = 'PUT'
+        Body   = $ConnectionData | ConvertTo-Json -Depth 10
+    }
+
+    $Response = InvokeADOPSRestMethod @InvokeSplat
+
+    return $Response
+}

--- a/Source/Public/New-ADOPSServiceConnection.ps1
+++ b/Source/Public/New-ADOPSServiceConnection.ps1
@@ -31,6 +31,11 @@ function New-ADOPSServiceConnection {
         [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
         [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$ConnectionName,
+
+        [Parameter(ParameterSetName = 'ServicePrincipal')]
+        [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
+        [string]$Description,
       
         [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
         [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]

--- a/Source/Public/Set-ADOPSServiceConnection.ps1
+++ b/Source/Public/Set-ADOPSServiceConnection.ps1
@@ -4,120 +4,68 @@ function Set-ADOPSServiceConnection {
         [Parameter()]
         [string]$Organization,
         
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName = 'GenericServiceConnection')]
+        $ConnectionData,
+
+        [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$TenantId,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$SubscriptionName,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$SubscriptionId,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$Project,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
         [guid]$ServiceEndpointId,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ServicePrincipal')]
+        [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$ConnectionName,
 
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ServicePrincipal')]
+        [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$Description,
         
-        [Parameter()]
+        [Parameter(ParameterSetName = 'ServicePrincipal')]
+        [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
+        [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
         [ValidateNotNullOrEmpty()]
         [string]$EndpointOperation,
       
         [Parameter(Mandatory, ParameterSetName = 'ServicePrincipal')]
+        [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
         [pscredential]$ServicePrincipal,
 
         [Parameter(Mandatory, ParameterSetName = 'ManagedServiceIdentity')]
-        [switch]$ManagedIdentity
+        [switch]$ManagedIdentity,
+
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
+        [switch]$WorkloadIdentityFederation,
+
+        [Parameter(Mandatory, ParameterSetName = 'WorkloadIdentityFederation')]
+        [string]$AzureScope
     )
     
-    process {
-
-        # If user didn't specify org, get it from saved context
-        if ([string]::IsNullOrEmpty($Organization)) {
-            $Organization = GetADOPSDefaultOrganization
-        }
-
-        # Get ProjectId
-        $ProjectInfo = Get-ADOPSProject -Organization $Organization -Project $Project
-
-        # Set connection name if not set by parameter
-        if (-not $ConnectionName) {
-            $ConnectionName = $SubscriptionName -replace " "
-        }
-
-        switch ($PSCmdlet.ParameterSetName) {
-        
-            'ServicePrincipal' {
-                $authorization = [ordered]@{
-                    parameters = [ordered]@{
-                        tenantid            = $TenantId
-                        serviceprincipalid  = $ServicePrincipal.UserName
-                        authenticationType  = "spnKey"
-                        serviceprincipalkey = $ServicePrincipal.GetNetworkCredential().Password
-                    }
-                    scheme     = "ServicePrincipal"
-                }
-        
-                $data = [ordered]@{
-                    subscriptionId   = $SubscriptionId
-                    subscriptionName = $SubscriptionName
-                    environment      = "AzureCloud"
-                    scopeLevel       = "Subscription"
-                    creationMode     = "Manual"
-                }
-            }
-    
-            'ManagedServiceIdentity' {
-                $authorization = [ordered]@{
-                    parameters = [ordered]@{
-                        tenantid = $TenantId
-                    }
-                    scheme     = "ManagedServiceIdentity"
-                }
-            }
-        }
-
-        # Create body for the API call
-        $Body = [ordered]@{
-            authorization                    = $authorization
-            data                             = $data
-            description                      = "$Description"
-            id                               = $ServiceConnectionId
-            isReady                          = $true
-            isShared                         = $false
-            name                             = ($SubscriptionName -replace " ")
-            serviceEndpointProjectReferences = @(
-                [ordered]@{
-                    projectReference = [ordered]@{
-                        id   = $ProjectInfo.Id
-                        name = $Project
-                    }
-                    name             = $ConnectionName
-                }
-            )
-            type                             = "AzureRM"
-            url                              = "https://management.azure.com/"
-        } | ConvertTo-Json -Depth 10
-    
-        if ($PSBoundParameters.ContainsKey('EndpointOperation')) {
-            $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?operation=$EndpointOperation`&api-version=7.1-preview.4"
-        }
-        else {
-            $URI = "https://dev.azure.com/$Organization/_apis/serviceendpoint/endpoints/$ServiceEndpointId`?api-version=7.1-preview.4"
-        }
-        
-        $InvokeSplat = @{
-            Uri          = $URI
-            Method       = "PUT"
-            Body         = $Body
-        }
-    
-        InvokeADOPSRestMethod @InvokeSplat
+    if ($PSCmdlet.ParameterSetName -in "ServicePrincipal", "ManagedServiceIdentity", "WorkloadIdentityFederation") {
+        return (SetAzureServiceConnection @PSBoundParameters)
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "GenericServiceConnection") {
+        return (SetGenericServiceConnection @PSBoundParameters)
     }
 }

--- a/Source/Public/Set-ADOPSServiceConnection.ps1
+++ b/Source/Public/Set-ADOPSServiceConnection.ps1
@@ -41,10 +41,7 @@ function Set-ADOPSServiceConnection {
         [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
         [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
         [string]$Description,
-        
-        [Parameter(ParameterSetName = 'ServicePrincipal')]
-        [Parameter(ParameterSetName = 'ManagedServiceIdentity')]
-        [Parameter(ParameterSetName = 'WorkloadIdentityFederation')]
+
         [ValidateNotNullOrEmpty()]
         [string]$EndpointOperation,
       

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -72,7 +72,6 @@ Describe 'New-ADOPSServiceConnection' {
     }
     
     Context "AzureResourceManagerConnectionArgumentTypes" {
-
         BeforeAll {
             Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'myorg' }
             
@@ -138,7 +137,6 @@ Describe 'New-ADOPSServiceConnection' {
     }
 
     Context "GenericServiceConnection" {
-
         BeforeAll {
             Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'myorg' }
             
@@ -154,26 +152,32 @@ Describe 'New-ADOPSServiceConnection' {
         BeforeEach {
             $Splat = @{
                 ConnectionData = [ordered]@{
-                    type          = "dockerregistry"
-                    name          = "Service Connection Name"
-                    description   = "Service Connection Description"
-                    authorization = [ordered]@{
+                    type                             = "dockerregistry"
+                    name                             = "Service Connection Name"
+                    description                      = "Service Connection Description"
+                    authorization                    = [ordered]@{
                         paramaters = [ordered]@{
                             registry = "dockerregistry.local"
                             username = "pipeline"
                             password = "supersecretpassword"
                             email    = "admin@dockerregistry.local"
                         }
+                        scheme     = "UsernamePassword"
                     }
-                    isSshared     = $false
-                    isReady       = $true
-                    owner         = "Library"
+                    isSshared                        = $false
+                    isReady                          = $true
+                    owner                            = "Library"
+                    serviceEndpointProjectReferences = @(
+                        [ordered]@{
+                            projectReference = [ordered]@{
+                                id   = "/43cf98ab-e228-451f-b0b1-05008d45460d"
+                                name = "myProject"
+                            }
+                            name             = "myNewServiceEndpoint"
+                        }            
+                    )
                 }
             }
-        }
-
-        It 'Test' {
-            Get-Help New-ADOPSServiceConnection -Full | Out-Host
         }
 
         It 'Should not get organization from GetADOPSDefaultOrganization when organization parameter is used' {
@@ -198,7 +202,7 @@ Describe 'New-ADOPSServiceConnection' {
                 -MockWith { return $body }
 
             $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Depth 10 -Compress
-            $r | Should -Be '{"type":"dockerregistry","name":"Service Connection Name","description":"Service Connection Description","authorization":{"paramaters":{"registry":"dockerregistry.local","username":"pipeline","password":"supersecretpassword","email":"admin@dockerregistry.local"}},"isSshared":false,"isReady":true,"owner":"Library"}'
+            $r | Should -Be '{"type":"dockerregistry","name":"Service Connection Name","description":"Service Connection Description","authorization":{"paramaters":{"registry":"dockerregistry.local","username":"pipeline","password":"supersecretpassword","email":"admin@dockerregistry.local"},"scheme":"UsernamePassword"},"isSshared":false,"isReady":true,"owner":"Library","serviceEndpointProjectReferences":[{"projectReference":{"id":"/43cf98ab-e228-451f-b0b1-05008d45460d","name":"myProject"},"name":"myNewServiceEndpoint"}]}'
         }
     }
 }

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -41,6 +41,11 @@ Describe 'New-ADOPSServiceConnection' {
                 Type      = 'string'
             },
             @{
+                Name      = 'Description'
+                Mandatory = $false
+                Type      = 'string'
+            },
+            @{
                 Name      = 'ConnectionData'
                 Mandatory = $true
             },
@@ -116,7 +121,7 @@ Describe 'New-ADOPSServiceConnection' {
             $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
             $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
-            $r | Should -Be '{"data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Manual"},"name":"AzureSubscriptionName","type":"AzureRM","url":"https://management.azure.com/","authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","authenticationType":"spnKey","serviceprincipalkey":"PassWord"},"scheme":"ServicePrincipal"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+            $r | Should -Be '{"name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Manual"},"authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","authenticationType":"spnKey","serviceprincipalkey":"PassWord"},"scheme":"ServicePrincipal"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
 
         It 'Verifying body is correct - ManagedServiceIdentity' {
@@ -124,7 +129,7 @@ Describe 'New-ADOPSServiceConnection' {
             $Splat.Add('ManagedIdentity', $true)
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
             $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
-            $r | Should -Be '{"data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription"},"name":"AzureSubscriptionName","type":"AzureRM","url":"https://management.azure.com/","authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","serviceprincipalkey":"PassWord"},"scheme":"ManagedServiceIdentity"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+            $r | Should -Be '{"name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription"},"authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","serviceprincipalkey":"PassWord"},"scheme":"ManagedServiceIdentity"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
 
         It 'Verifying body is correct - WorkloadIdentityFederation' {
@@ -132,7 +137,7 @@ Describe 'New-ADOPSServiceConnection' {
             $Splat.Add('AzureScope', 'Azure/Scope')
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
             $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
-            $r | Should -Be '{"data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Automatic"},"name":"AzureSubscriptionName","type":"AzureRM","url":"https://management.azure.com/","authorization":{"parameters":{"tenantid":"AzureTennantId","scope":"Azure/Scope"},"scheme":"WorkloadIdentityFederation"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+            $r | Should -Be '{"name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Automatic"},"authorization":{"parameters":{"tenantid":"AzureTennantId","scope":"Azure/Scope"},"scheme":"WorkloadIdentityFederation"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
     }
 

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -76,7 +76,7 @@ Describe 'New-ADOPSServiceConnection' {
         }
     }
     
-    Context "AzureResourceManagerConnectionArgumentTypes" {
+    Context "AzureResourceManagerConnection" {
         BeforeAll {
             Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'myorg' }
             
@@ -116,7 +116,7 @@ Describe 'New-ADOPSServiceConnection' {
             $r = New-ADOPSServiceConnection @Splat
             $r | Should -Be 'https://dev.azure.com/myorg/myproj/_apis/serviceendpoint/endpoints?api-version=7.2-preview.4'
         }
-
+        
         It 'Verifying body is correct - ServicePrincipal' {
             $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }

--- a/Tests/New-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/New-ADOPSServiceConnection.Tests.ps1
@@ -175,7 +175,7 @@ Describe 'New-ADOPSServiceConnection' {
                     serviceEndpointProjectReferences = @(
                         [ordered]@{
                             projectReference = [ordered]@{
-                                id   = "/43cf98ab-e228-451f-b0b1-05008d45460d"
+                                id   = "43cf98ab-e228-451f-b0b1-05008d45460d"
                                 name = "myProject"
                             }
                             name             = "myNewServiceEndpoint"
@@ -196,18 +196,21 @@ Describe 'New-ADOPSServiceConnection' {
         }
 
         It 'Verifying URI is correct' {
-            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $URI }
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
+                -ParameterFilter { $Method -eq "POST" } `
+                -MockWith { return $URI }
+
             $r = New-ADOPSServiceConnection @Splat
             $r | Should -Be 'https://dev.azure.com/myorg/_apis/serviceendpoint/endpoints?api-version=7.2-preview.4'
         }
 
         It 'Verifying body is correct - GenericServiceConnection' {
             Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
-                -ParameterFilter { $Uri -like "*_apis/serviceendpoint/endpoints*" } `
+                -ParameterFilter { ($Method -eq "POST") -and ($Uri -like "*_apis/serviceendpoint/endpoints*") } `
                 -MockWith { return $body }
 
             $r = New-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Depth 10 -Compress
-            $r | Should -Be '{"type":"dockerregistry","name":"Service Connection Name","description":"Service Connection Description","authorization":{"paramaters":{"registry":"dockerregistry.local","username":"pipeline","password":"supersecretpassword","email":"admin@dockerregistry.local"},"scheme":"UsernamePassword"},"isSshared":false,"isReady":true,"owner":"Library","serviceEndpointProjectReferences":[{"projectReference":{"id":"/43cf98ab-e228-451f-b0b1-05008d45460d","name":"myProject"},"name":"myNewServiceEndpoint"}]}'
+            $r | Should -Be '{"type":"dockerregistry","name":"Service Connection Name","description":"Service Connection Description","authorization":{"paramaters":{"registry":"dockerregistry.local","username":"pipeline","password":"supersecretpassword","email":"admin@dockerregistry.local"},"scheme":"UsernamePassword"},"isSshared":false,"isReady":true,"owner":"Library","serviceEndpointProjectReferences":[{"projectReference":{"id":"43cf98ab-e228-451f-b0b1-05008d45460d","name":"myProject"},"name":"myNewServiceEndpoint"}]}'
         }
     }
 }

--- a/Tests/Set-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Set-ADOPSServiceConnection.Tests.ps1
@@ -127,14 +127,18 @@ Describe 'Set-ADOPSServiceConnection' {
 
         It 'Verifying URI is correct with EndpointOperation' {
             $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
-            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $URI }
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
+                -ParameterFilter { $Method -eq "PUT" } `
+                -MockWith { return $URI }
             $r = Set-ADOPSServiceConnection @Splat -EndpointOperation "noop"
             $r | Should -Be 'https://dev.azure.com/DummyOrg/_apis/serviceendpoint/endpoints/8bce170f-ac4e-4164-a7d7-6cbc8f69f6af?operation=noop&api-version=7.1-preview.4'
         }
 
         It 'Verifying body is correct - ServicePrincipal' {
             $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
-            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
+                -ParameterFilter { $Method -eq "PUT" } `
+                -MockWith { return $body }
             $r = Set-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
             $r | Should -Be '{"id":"8bce170f-ac4e-4164-a7d7-6cbc8f69f6af","name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Manual"},"authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","authenticationType":"spnKey","serviceprincipalkey":"PassWord"},"scheme":"ServicePrincipal"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
@@ -155,4 +159,87 @@ Describe 'Set-ADOPSServiceConnection' {
             $r | Should -Be '{"id":"8bce170f-ac4e-4164-a7d7-6cbc8f69f6af","name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Automatic"},"authorization":{"parameters":{"tenantid":"AzureTennantId","scope":"Azure/Scope"},"scheme":"WorkloadIdentityFederation"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
     }
+
+    Context "GenericServiceConnection" {
+        BeforeAll {
+            Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'myorg' }
+            
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {}
+    
+            Mock -CommandName Get-ADOPSProject -ModuleName ADOPS -MockWith {
+                @{
+                    id = 'ProjectInfoId'
+                }
+            }
+        }
+        
+        BeforeEach {
+            $Splat = @{
+                ConnectionData = [ordered]@{
+                    id                               = '8bce170f-ac4e-4164-a7d7-6cbc8f69f6af'
+                    type                             = "dockerregistry"
+                    name                             = "Service Connection Name"
+                    description                      = "Service Connection Description"
+                    authorization                    = [ordered]@{
+                        paramaters = [ordered]@{
+                            registry = "dockerregistry.local"
+                            username = "pipeline"
+                            password = "supersecretpassword"
+                            email    = "admin@dockerregistry.local"
+                        }
+                        scheme     = "UsernamePassword"
+                    }
+                    isSshared                        = $false
+                    isReady                          = $true
+                    owner                            = "Library"
+                    serviceEndpointProjectReferences = @(
+                        [ordered]@{
+                            projectReference = [ordered]@{
+                                id   = "43cf98ab-e228-451f-b0b1-05008d45460d"
+                                name = "myProject"
+                            }
+                            name             = "myNewServiceEndpoint"
+                        }            
+                    )
+                }
+            }
+        }
+
+        It 'Should not get organization from GetADOPSDefaultOrganization when organization parameter is used' {
+            Set-ADOPSServiceConnection -Organization 'anotherorg' @Splat
+            Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 0 -Exactly
+        }
+
+        It 'Should get organization using GetADOPSDefaultOrganization when organization parameter is not used' {
+            Set-ADOPSServiceConnection @Splat
+            Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 1 -Exactly
+        }
+
+        It 'Verifying URI is correct' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
+                -ParameterFilter { $Method -eq "PUT" } `
+                -MockWith { return $URI }
+
+            $r = Set-ADOPSServiceConnection @Splat
+            $r | Should -Be 'https://dev.azure.com/myorg/_apis/serviceendpoint/endpoints/8bce170f-ac4e-4164-a7d7-6cbc8f69f6af?api-version=7.1-preview.4'
+        }
+
+        It 'Verifying URI is correct with EndpointOperation' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
+                -ParameterFilter { ($Method -eq "PUT") } `
+                -MockWith { return $URI }
+            $r = Set-ADOPSServiceConnection @Splat -EndpointOperation "noop"
+            $r | Should -Be 'https://dev.azure.com/myorg/_apis/serviceendpoint/endpoints/8bce170f-ac4e-4164-a7d7-6cbc8f69f6af?operation=noop&api-version=7.1-preview.4'
+        }
+
+        It 'Verifying body is correct - GenericServiceConnection' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS `
+                -ParameterFilter { ($Method -eq "PUT") -and ($Uri -like "*_apis/serviceendpoint/endpoints*") } `
+                -MockWith { return $body }
+    
+            $r = Set-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Depth 10 -Compress
+            $r | Should -Be '{"id":"8bce170f-ac4e-4164-a7d7-6cbc8f69f6af","type":"dockerregistry","name":"Service Connection Name","description":"Service Connection Description","authorization":{"paramaters":{"registry":"dockerregistry.local","username":"pipeline","password":"supersecretpassword","email":"admin@dockerregistry.local"},"scheme":"UsernamePassword"},"isSshared":false,"isReady":true,"owner":"Library","serviceEndpointProjectReferences":[{"projectReference":{"id":"43cf98ab-e228-451f-b0b1-05008d45460d","name":"myProject"},"name":"myNewServiceEndpoint"}]}'
+        }
+    }
+
 }

--- a/Tests/Set-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Set-ADOPSServiceConnection.Tests.ps1
@@ -11,63 +11,79 @@ Describe 'Set-ADOPSServiceConnection' {
     Context 'Parameters' {
         $TestCases = @(
             @{
-                Name = 'Organization'
+                Name      = 'Organization'
                 Mandatory = $false
-                Type = 'string'
+                Type      = 'string'
             },
             @{
-                Name = 'TenantId'
+                Name      = 'TenantId'
                 Mandatory = $true
-                Type = 'string'
+                Type      = 'string'
             },
             @{
-                Name = 'SubscriptionName'
+                Name      = 'SubscriptionName'
                 Mandatory = $true
-                Type = 'string'
+                Type      = 'string'
             },
             @{
-                Name = 'SubscriptionId'
+                Name      = 'SubscriptionId'
                 Mandatory = $true
-                Type = 'string'
+                Type      = 'string'
             },
             @{
-                Name = 'Project'
+                Name      = 'Project'
                 Mandatory = $true
-                Type = 'string'
+                Type      = 'string'
             },
             @{
-                Name = 'ConnectionName'
+                Name      = 'ConnectionName'
                 Mandatory = $false
-                Type = 'string'
+                Type      = 'string'
             },
             @{
-                Name = 'ServicePrincipal'
-                Mandatory = $true
-                Type = 'pscredential'
-            },
-            @{
-                Name = 'ManagedIdentity'
-                Mandatory = $true
-                Type = 'switch'
-            },
-            @{
-                Name = 'ServiceEndpointId'
-                Mandatory = $true
-                Type = 'guid'
-            },@{
-                Name = 'EndpointOperation'
+                Name      = 'Description'
                 Mandatory = $false
-                Type = 'string'
+                Type      = 'string'
+            },
+            @{
+                Name      = 'ServicePrincipal'
+                Mandatory = $true
+                Type      = 'pscredential'
+            },
+            @{
+                Name      = 'ManagedIdentity'
+                Mandatory = $true
+                Type      = 'switch'
+            },
+            @{
+                Name      = 'ServiceEndpointId'
+                Mandatory = $true
+                Type      = 'guid'
+            },
+            @{
+                Name      = 'EndpointOperation'
+                Mandatory = $false
+                Type      = 'string'
+            },
+            @{
+                Name      = 'WorkloadIdentityFederation'
+                Mandatory = $true
+                Type      = 'switch'
+            },
+            @{
+                Name      = 'AzureScope'
+                Mandatory = $true
+                Type      = 'string'
             }
             
         )
     
-        It 'Should have parameter <_.Name>' -TestCases $TestCases  {
+        It 'Should have parameter <_.Name>' -TestCases $TestCases {
             Get-Command Set-ADOPSServiceConnection | Should -HaveParameter $_.Name -Mandatory:$_.Mandatory -Type $_.Type
         }
     }
     
-    Context "Functionality" {
+    Context "AzureResourceManagerConnection" {
         BeforeAll {
             Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'DummyOrg' }
             
@@ -78,25 +94,65 @@ Describe 'Set-ADOPSServiceConnection' {
                     id = 'ProjectInfoId'
                 }
             }
-            
+        }
+
+        BeforeEach {
             $Splat = @{
-                Project = 'myproj' 
-                TenantId = 'AzureTennantId' 
-                SubscriptionName = 'AzureSubscriptionName' 
-                SubscriptionId = 'AzureSubscriptionId' 
+                Project           = 'myproj' 
+                TenantId          = 'AzureTennantId' 
+                SubscriptionName  = 'AzureSubscriptionName' 
+                SubscriptionId    = 'AzureSubscriptionId' 
                 ServiceEndpointId = '8bce170f-ac4e-4164-a7d7-6cbc8f69f6af'
-                ServicePrincipal = [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force))
             }
         }
         
         It 'Should not get organization from GetADOPSDefaultOrganization when organization parameter is used' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             Set-ADOPSServiceConnection -Organization 'anotherorg' @Splat
             Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 0 -Exactly
         }
 
         It 'Should get organization using GetADOPSDefaultOrganization when organization parameter is not used' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
             Set-ADOPSServiceConnection @Splat
             Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 1 -Exactly
+        }
+
+        It 'Verifying URI is correct' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $URI }
+            $r = Set-ADOPSServiceConnection @Splat
+            $r | Should -Be 'https://dev.azure.com/DummyOrg/_apis/serviceendpoint/endpoints/8bce170f-ac4e-4164-a7d7-6cbc8f69f6af?api-version=7.1-preview.4'
+        }
+
+        It 'Verifying URI is correct with EndpointOperation' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $URI }
+            $r = Set-ADOPSServiceConnection @Splat -EndpointOperation "noop"
+            $r | Should -Be 'https://dev.azure.com/DummyOrg/_apis/serviceendpoint/endpoints/8bce170f-ac4e-4164-a7d7-6cbc8f69f6af?operation=noop&api-version=7.1-preview.4'
+        }
+
+        It 'Verifying body is correct - ServicePrincipal' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
+            $r = Set-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
+            $r | Should -Be '{"id":"8bce170f-ac4e-4164-a7d7-6cbc8f69f6af","name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Manual"},"authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","authenticationType":"spnKey","serviceprincipalkey":"PassWord"},"scheme":"ServicePrincipal"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+        }
+
+        It 'Verifying body is correct - ManagedServiceIdentity' {
+            $Splat.Add('ServicePrincipal', [pscredential]::new('User', (ConvertTo-SecureString -String 'PassWord' -AsPlainText -Force)))
+            $Splat.Add('ManagedIdentity', $true)
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
+            $r = Set-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
+            $r | Should -Be '{"id":"8bce170f-ac4e-4164-a7d7-6cbc8f69f6af","name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription"},"authorization":{"parameters":{"tenantid":"AzureTennantId","serviceprincipalid":"User","serviceprincipalkey":"PassWord"},"scheme":"ManagedServiceIdentity"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
+        }
+
+        It 'Verifying body is correct - WorkloadIdentityFederation' {
+            $Splat.Add('WorkloadIdentityFederation', $true)
+            $Splat.Add('AzureScope', 'Azure/Scope')
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith { return $body }
+            $r = Set-ADOPSServiceConnection @Splat | ConvertFrom-Json | ConvertTo-Json -Compress -Depth 10
+            $r | Should -Be '{"id":"8bce170f-ac4e-4164-a7d7-6cbc8f69f6af","name":"AzureSubscriptionName","description":"","type":"AzureRM","url":"https://management.azure.com/","data":{"subscriptionId":"AzureSubscriptionId","subscriptionName":"AzureSubscriptionName","environment":"AzureCloud","scopeLevel":"Subscription","creationMode":"Automatic"},"authorization":{"parameters":{"tenantid":"AzureTennantId","scope":"Azure/Scope"},"scheme":"WorkloadIdentityFederation"},"isShared":false,"isReady":true,"serviceEndpointProjectReferences":[{"projectReference":{"id":"ProjectInfoId","name":"myproj"},"name":"AzureSubscriptionName"}]}'
         }
     }
 }


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/ADOPS/ADOPS/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Overview/Summary

Implemented a new parameter set `GenericServiceConnection`. This can be used to create non azure resource manager service connections.

## This PR fixes/adds/changes/removes

1. New cmdlet parameter set **GenericServiceConnection** for `New-ADOPSServiceConnection`/`Set-ADOPSServiceConnection`. Resolves #218.
2. New cmdlet parameter set **WorkloadIdentityFederation** for  `Set-ADOPSServiceConnection`
3. New optional parameter `description` to `New-ADOPSServiceConnection` parameter sets `ServicePrincipal`, `ManagedServiceIdentity`, and `WorkloadIdentityFederation`
4. Added several more tests to `Set-ADOPSServiceConnection`

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [X] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Verified build scripts work.
- [X] Updated relevant and associated documentation.
