### PR TITLE
New cmd new adops group entitlement

### DIFF
--- a/Docs/Help/Add-ADOPSGroupEntitlement.md
+++ b/Docs/Help/Add-ADOPSGroupEntitlement.md
@@ -1,0 +1,173 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Add-ADOPSGroupEntitlement
+
+## SYNOPSIS
+
+Adds a group entitlement in Azure DevOps.
+
+## SYNTAX
+
+```
+Add-ADOPSGroupEntitlement -GroupOriginId <String> -AccountLicenseType <String> -ProjectGroupType <String> -ProjectId <String>
+ [-LicensingSource <String>] [-Organization <String>] [-Wait] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Adds a group entitlement in Azure DevOps, allowing you to manage licensing and access levels for Entra ID groups.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+PS C:\> Add-ADOPSGroupEntitlement -GroupOriginId "01d0472d-9949-421e-81d8-fcb5668a394d" -AccountLicenseType "Express" -ProjectGroupType "projectContributor" -ProjectId "8130f18e-f65b-431d-a777-5d4a6f3468ba"
+```
+
+Adds a group entitlement for the specified Entra ID group with Express license and Contributor access to the specified project.
+
+### Example 2
+
+```powershell
+PS C:\> Add-ADOPSGroupEntitlement -GroupOriginId "01d0472d-9949-421e-81d8-fcb5668a394d" -AccountLicenseType "Stakeholder" -ProjectGroupType "projectReader" -ProjectId "8130f18e-f65b-431d-a777-5d4a6f3468ba" -Organization "MyOrg" -Wait
+```
+
+Adds a group entitlement with Stakeholder license and Reader access to the specified project in the "MyOrg" organization, waiting for the operation to complete.
+
+## PARAMETERS
+
+### -GroupOriginId
+
+The ID of the Entra ID group to add entitlements for.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AccountLicenseType
+
+The type of license to assign to the group.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Express, Advanced, Stakeholder, Professional, EarlyAdopter
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectGroupType
+
+The type of access to grant in the project.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: projectReader, projectContributor, projectAdministrator, projectStakeholder
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+
+The ID of the project to grant access to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LicensingSource
+
+The source of licensing. Currently only supports 'account'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: account
+
+Required: False
+Position: Named
+Default value: account
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Organization
+
+The Azure DevOps organization.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Wait
+
+If specified, waits for the operation to complete before returning.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+## RELATED LINKS

--- a/Docs/Help/New-ADOPSGroupEntitlement.md
+++ b/Docs/Help/New-ADOPSGroupEntitlement.md
@@ -5,7 +5,7 @@ online version:
 schema: 2.0.0
 ---
 
-# Add-ADOPSGroupEntitlement
+# New-ADOPSGroupEntitlement
 
 ## SYNOPSIS
 
@@ -14,7 +14,7 @@ Adds a group entitlement in Azure DevOps.
 ## SYNTAX
 
 ```
-Add-ADOPSGroupEntitlement -GroupOriginId <String> -AccountLicenseType <String> -ProjectGroupType <String> -ProjectId <String>
+New-ADOPSGroupEntitlement -GroupOriginId <String> -AccountLicenseType <String> -ProjectGroupType <String> -ProjectId <String>
  [-LicensingSource <String>] [-Organization <String>] [-Wait] [<CommonParameters>]
 ```
 
@@ -27,7 +27,7 @@ Adds a group entitlement in Azure DevOps, allowing you to manage licensing and a
 ### Example 1
 
 ```powershell
-PS C:\> Add-ADOPSGroupEntitlement -GroupOriginId "01d0472d-9949-421e-81d8-fcb5668a394d" -AccountLicenseType "Express" -ProjectGroupType "projectContributor" -ProjectId "8130f18e-f65b-431d-a777-5d4a6f3468ba"
+PS C:\> New-ADOPSGroupEntitlement -GroupOriginId "01d0472d-9949-421e-81d8-fcb5668a394d" -AccountLicenseType "Express" -ProjectGroupType "projectContributor" -ProjectId "8130f18e-f65b-431d-a777-5d4a6f3468ba"
 ```
 
 Adds a group entitlement for the specified Entra ID group with Express license and Contributor access to the specified project.
@@ -35,7 +35,7 @@ Adds a group entitlement for the specified Entra ID group with Express license a
 ### Example 2
 
 ```powershell
-PS C:\> Add-ADOPSGroupEntitlement -GroupOriginId "01d0472d-9949-421e-81d8-fcb5668a394d" -AccountLicenseType "Stakeholder" -ProjectGroupType "projectReader" -ProjectId "8130f18e-f65b-431d-a777-5d4a6f3468ba" -Organization "MyOrg" -Wait
+PS C:\> New-ADOPSGroupEntitlement -GroupOriginId "01d0472d-9949-421e-81d8-fcb5668a394d" -AccountLicenseType "Stakeholder" -ProjectGroupType "projectReader" -ProjectId "8130f18e-f65b-431d-a777-5d4a6f3468ba" -Organization "MyOrg" -Wait
 ```
 
 Adds a group entitlement with Stakeholder license and Reader access to the specified project in the "MyOrg" organization, waiting for the operation to complete.

--- a/Docs/Help/New-ADOPSGroupEntitlement.md
+++ b/Docs/Help/New-ADOPSGroupEntitlement.md
@@ -15,7 +15,7 @@ Adds a group entitlement in Azure DevOps.
 
 ```
 New-ADOPSGroupEntitlement -GroupOriginId <String> -AccountLicenseType <String> -ProjectGroupType <String> -ProjectId <String>
- [-LicensingSource <String>] [-Organization <String>] [-Wait] [<CommonParameters>]
+ [-Organization <String>] [-Wait] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -104,23 +104,6 @@ Aliases:
 Required: True
 Position: Named
 Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -LicensingSource
-
-The source of licensing. Currently only supports 'account'.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-Accepted values: account
-
-Required: False
-Position: Named
-Default value: account
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/Source/Public/New-ADOPSGroupEntitlement.ps1
+++ b/Source/Public/New-ADOPSGroupEntitlement.ps1
@@ -5,10 +5,6 @@ function New-ADOPSGroupEntitlement {
         [ValidateNotNullOrEmpty()]
         [string]$GroupOriginId,
 
-        [Parameter()]
-        [ValidateSet('account')]
-        [string]$LicensingSource = 'account',
-
         [Parameter(Mandatory)]
         [ValidateSet('Express', 'Advanced', 'Stakeholder', 'Professional', 'EarlyAdopter')]
         [string]$AccountLicenseType,

--- a/Source/Public/New-ADOPSGroupEntitlement.ps1
+++ b/Source/Public/New-ADOPSGroupEntitlement.ps1
@@ -1,0 +1,84 @@
+function New-ADOPSGroupEntitlement {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$GroupOriginId,
+
+        [Parameter()]
+        [ValidateSet('account')]
+        [string]$LicensingSource = 'account',
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Express', 'Advanced', 'Stakeholder', 'Professional', 'EarlyAdopter')]
+        [string]$AccountLicenseType,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('projectReader', 'projectContributor', 'projectAdministrator', 'projectStakeholder')]
+        [string]$ProjectGroupType,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ProjectId,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Organization,
+
+        [Parameter()]
+        [switch]$Wait
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+
+    # Group entitlements endpoint
+    $URI = "https://vsaex.dev.azure.com/$Organization/_apis/GroupEntitlements?api-version=7.1"
+
+    # Initialize the request body
+    $Body = @{
+        extensionRules = @(
+            @{
+                id = 'ms.feed'
+            }
+        )
+        group = @{
+            origin = 'aad'
+            originId = $GroupOriginId
+            subjectKind = 'group'
+        }
+        licenseRule = @{
+            licensingSource = 'account'
+            accountLicenseType = $AccountLicenseType
+        }
+        projectEntitlements = @(
+            @{
+                group = @{
+                    groupType = $ProjectGroupType
+                }
+                projectRef = @{
+                    id = $ProjectId
+                }
+            }
+        )
+    }
+
+    $InvokeSplat = @{
+        Method = 'Post'
+        Uri = $URI
+        Body = ($Body | ConvertTo-Json -Compress -Depth 10)
+    }
+
+    $Out = InvokeADOPSRestMethod @InvokeSplat
+
+    if ($PSBoundParameters.ContainsKey('Wait')) {
+        while ($Out.operationResult.status -eq 'inProgress') {
+            Start-Sleep -Seconds 1
+            $Out = Invoke-ADOPSRestMethod -Uri $Out.operationResult.statusUrl -Method Get
+        }
+    }
+
+    $Out
+}

--- a/Tests/New-ADOPSGroupEntitlement.Tests.ps1
+++ b/Tests/New-ADOPSGroupEntitlement.Tests.ps1
@@ -104,7 +104,7 @@ Describe 'New-ADOPSGroupEntitlement' {
                 return $uri
             } -ParameterFilter { $Method -eq 'Post' }
 
-            $result = New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId
+            $result = New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor'
             $result.OriginalString | Should -Be "https://vsaex.dev.azure.com/$testOrgName/_apis/GroupEntitlements?api-version=7.1"
         }
     }

--- a/Tests/New-ADOPSGroupEntitlement.Tests.ps1
+++ b/Tests/New-ADOPSGroupEntitlement.Tests.ps1
@@ -90,7 +90,14 @@ Describe 'New-ADOPSGroupEntitlement' {
             } -ParameterFilter { $Method -eq 'Post' }
 
             $result = New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor'
-            $result | Should -Be '{"extensionRules":[{"id":"ms.feed"}],"group":{"origin":"aad","originId":"01d0472d-9949-421e-81d8-fcb5668a394d","subjectKind":"group"},"licenseRule":{"licensingSource":"account","accountLicenseType":"Express"},"projectEntitlements":[{"group":{"groupType":"projectContributor"},"projectRef":{"id":"8130f18e-f65b-431d-a777-5d4a6f3468ba"}}]}'
+            $resultObj = $result | ConvertFrom-Json
+            $resultObj.group.origin | Should -Be 'aad'
+            $resultObj.group.originId | Should -Be $testGroupId
+            $resultObj.group.subjectKind | Should -Be 'group'
+            $resultObj.licenseRule.licensingSource | Should -Be 'account'
+            $resultObj.licenseRule.accountLicenseType | Should -Be 'Express'
+            $resultObj.projectEntitlements[0].group.groupType | Should -Be 'projectContributor'
+            $resultObj.projectEntitlements[0].projectRef.id | Should -Be $testProjectId
         }
     }
 }

--- a/Tests/New-ADOPSGroupEntitlement.Tests.ps1
+++ b/Tests/New-ADOPSGroupEntitlement.Tests.ps1
@@ -71,30 +71,6 @@ Describe 'New-ADOPSGroupEntitlement' {
             Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
         }
 
-        It 'should throw with missing GroupOriginId parameter' {
-            { New-ADOPSGroupEntitlement -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor' } | Should -Throw
-        }
-
-        It 'should throw with missing AccountLicenseType parameter' {
-            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -ProjectGroupType 'projectContributor' } | Should -Throw
-        }
-
-        It 'should throw with missing ProjectGroupType parameter' {
-            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' } | Should -Throw
-        }
-
-        It 'should throw with missing ProjectId parameter' {
-            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor' } | Should -Throw
-        }
-
-        It 'should throw with invalid AccountLicenseType parameter' {
-            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Invalid' -ProjectGroupType 'projectContributor' } | Should -Throw
-        }
-
-        It 'should throw with invalid ProjectGroupType parameter' {
-            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'Invalid' } | Should -Throw
-        }
-
         It 'should not throw with all mandatory parameters' {
             { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor' } | Should -Not -Throw
         }
@@ -106,6 +82,15 @@ Describe 'New-ADOPSGroupEntitlement' {
 
             $result = New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor'
             $result.OriginalString | Should -Be "https://vsaex.dev.azure.com/$testOrgName/_apis/GroupEntitlements?api-version=7.1"
+        }
+
+        It 'Verify body' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return $body
+            } -ParameterFilter { $Method -eq 'Post' }
+
+            $result = New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor'
+            $result | Should -Be '{"extensionRules":[{"id":"ms.feed"}],"group":{"origin":"aad","originId":"01d0472d-9949-421e-81d8-fcb5668a394d","subjectKind":"group"},"licenseRule":{"licensingSource":"account","accountLicenseType":"Express"},"projectEntitlements":[{"group":{"groupType":"projectContributor"},"projectRef":{"id":"8130f18e-f65b-431d-a777-5d4a6f3468ba"}}]}'
         }
     }
 }

--- a/Tests/New-ADOPSGroupEntitlement.Tests.ps1
+++ b/Tests/New-ADOPSGroupEntitlement.Tests.ps1
@@ -16,11 +16,6 @@ Describe 'New-ADOPSGroupEntitlement' {
                 Type = 'string'
             },
             @{
-                Name = 'LicensingSource'
-                Mandatory = $false
-                Type = 'string'
-            },
-            @{
                 Name = 'AccountLicenseType'
                 Mandatory = $true
                 Type = 'string'
@@ -94,7 +89,6 @@ Describe 'New-ADOPSGroupEntitlement' {
             $resultObj.group.origin | Should -Be 'aad'
             $resultObj.group.originId | Should -Be $testGroupId
             $resultObj.group.subjectKind | Should -Be 'group'
-            $resultObj.licenseRule.licensingSource | Should -Be 'account'
             $resultObj.licenseRule.accountLicenseType | Should -Be 'Express'
             $resultObj.projectEntitlements[0].group.groupType | Should -Be 'projectContributor'
             $resultObj.projectEntitlements[0].projectRef.id | Should -Be $testProjectId

--- a/Tests/New-ADOPSGroupEntitlement.Tests.ps1
+++ b/Tests/New-ADOPSGroupEntitlement.Tests.ps1
@@ -1,0 +1,111 @@
+param(
+    $PSM1 = "$PSScriptRoot\..\Source\ADOPS.psm1"
+)
+
+BeforeAll {
+    Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
+    Import-Module $PSM1 -Force
+}
+
+Describe 'New-ADOPSGroupEntitlement' {
+    Context 'Parameters' {
+        $TestCases = @(
+            @{
+                Name = 'GroupOriginId'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'LicensingSource'
+                Mandatory = $false
+                Type = 'string'
+            },
+            @{
+                Name = 'AccountLicenseType'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'ProjectGroupType'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'ProjectId'
+                Mandatory = $true
+                Type = 'string'
+            },
+            @{
+                Name = 'Organization'
+                Mandatory = $false
+                Type = 'string'
+            },
+            @{
+                Name = 'Wait'
+                Mandatory = $false
+                Type = 'switch'
+            }
+        )
+    
+        It 'Should have parameter <_.Name>' -TestCases $TestCases {
+            Get-Command New-ADOPSGroupEntitlement | Should -HaveParameter $_.Name -Mandatory:$_.Mandatory -Type $_.Type
+        }
+    }
+
+    Context 'Adding group entitlement' {
+        BeforeEach {
+            Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'myorg' }
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return $InvokeSplat
+            } -ParameterFilter { $Method -eq 'Post' }
+        }
+
+        BeforeAll {
+            $script:testOrgName = 'DummyOrg'
+            $script:testGroupId = '01d0472d-9949-421e-81d8-fcb5668a394d'
+            $script:testProjectId = '8130f18e-f65b-431d-a777-5d4a6f3468ba'
+        }
+
+        It 'uses InvokeADOPSRestMethod once without wait parameter' {
+            New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor'
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 1
+        }
+
+        It 'should throw with missing GroupOriginId parameter' {
+            { New-ADOPSGroupEntitlement -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor' } | Should -Throw
+        }
+
+        It 'should throw with missing AccountLicenseType parameter' {
+            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -ProjectGroupType 'projectContributor' } | Should -Throw
+        }
+
+        It 'should throw with missing ProjectGroupType parameter' {
+            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' } | Should -Throw
+        }
+
+        It 'should throw with missing ProjectId parameter' {
+            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor' } | Should -Throw
+        }
+
+        It 'should throw with invalid AccountLicenseType parameter' {
+            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Invalid' -ProjectGroupType 'projectContributor' } | Should -Throw
+        }
+
+        It 'should throw with invalid ProjectGroupType parameter' {
+            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'Invalid' } | Should -Throw
+        }
+
+        It 'should not throw with all mandatory parameters' {
+            { New-ADOPSGroupEntitlement -GroupOriginId $testGroupId -ProjectId $testProjectId -AccountLicenseType 'Express' -ProjectGroupType 'projectContributor' } | Should -Not -Throw
+        }
+
+        It 'Verify uri' {
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return $uri
+            } -ParameterFilter { $Method -eq 'Post' }
+
+            $result = New-ADOPSGroupEntitlement -Organization $testOrgName -GroupOriginId $testGroupId -ProjectId $testProjectId
+            $result.OriginalString | Should -Be "https://vsaex.dev.azure.com/$testOrgName/_apis/GroupEntitlements?api-version=7.1"
+        }
+    }
+}


### PR DESCRIPTION
# Contributing a Pull Request

## Overview/Summary

This PR adds a new command Add-ADOPSGroupEntitlement that enables managing group entitlements in Azure DevOps through PowerShell. The command allows users to assign licenses and project access levels to Entra ID groups, making it easier to manage permissions and access at scale.

## This PR fixes/adds/changes/removes

- Adds new command Add-ADOPSGroupEntitlement (#241)
- Adds comprehensive test coverage for the new command
- Adds detailed help documentation with examples

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.
