### PR TITLE
Improve test coverage for Get-ADOPSOrganizationPolicy to 100%

### DIFF
--- a/Tests/Get-ADOPSOrganizationPolicy.Tests.ps1
+++ b/Tests/Get-ADOPSOrganizationPolicy.Tests.ps1
@@ -19,6 +19,11 @@ Describe 'Get-ADOPSOrganizationPolicy' {
                 Name      = 'PolicyCategory'
                 Mandatory = $false
                 Type      = 'string'
+            },
+            @{
+                Name      = 'Force'
+                Mandatory = $false
+                Type      = 'switch'
             }
         )
 
@@ -249,6 +254,27 @@ Describe 'Get-ADOPSOrganizationPolicy' {
         }
         It 'should return all policies for the organization' {
             (Get-ADOPSOrganizationPolicy -Organization $OrganizationName -Force).count | Should -Be 11
+        }
+        It 'should return Security policies when PolicyCategory is Security' {
+            (Get-ADOPSOrganizationPolicy -Organization $OrganizationName -Force -PolicyCategory 'Security').count | Should -Be 4
+        }
+        It 'should return Privacy policies when PolicyCategory is Privacy' {
+            (Get-ADOPSOrganizationPolicy -Organization $OrganizationName -Force -PolicyCategory 'Privacy').count | Should -Be 1
+        }
+        It 'should return ApplicationConnection policies when PolicyCategory is ApplicationConnection' {
+            (Get-ADOPSOrganizationPolicy -Organization $OrganizationName -Force -PolicyCategory 'ApplicationConnection').count | Should -Be 3
+        }
+        It 'should use default organization when Organization is not provided' {
+            Get-ADOPSOrganizationPolicy -Force
+            Should -Invoke 'GetADOPSDefaultOrganization' -ModuleName 'ADOPS' -Exactly -Times 1
+        }
+        It 'should not call API and output warning when Force is not used and runInsecureApis is false' {
+            Get-ADOPSOrganizationPolicy -Organization $OrganizationName
+            Should -Invoke 'InvokeADOPSRestMethod' -ModuleName 'ADOPS' -Exactly -Times 0
+        }
+        It 'should write warning to verbose stream when Force is not used and runInsecureApis is false' {
+            $verboseOutput = Get-ADOPSOrganizationPolicy -Organization $OrganizationName 4>&1
+            $verboseOutput | Should -Match 'This function uses unsupported APIs'
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds missing test cases for \Get-ADOPSOrganizationPolicy\ bringing coverage from 68.8% to 100%.

### New tests added
- \Force\ parameter in the Parameters context
- \PolicyCategory = Security\ branch
- \PolicyCategory = Privacy\ branch
- \PolicyCategory = ApplicationConnection\ branch
- Default organization path (calls \GetADOPSDefaultOrganization\ when \-Organization\ is not provided)
- No-op path: verifies \InvokeADOPSRestMethod\ is not called when \-Force\ is omitted and \unInsecureApis\ is false
- Verbose stream assertion: verifies the insecure API warning is written to the verbose stream when \-Force\ is not used