### PR TITLE
Add tests for ManagedServiceIdentity, WorkloadIdentityFederation, and…

### DIFF
--- a/Tests/Set-ADOPSServiceConnection.Tests.ps1
+++ b/Tests/Set-ADOPSServiceConnection.Tests.ps1
@@ -110,5 +110,51 @@ Describe 'Set-ADOPSServiceConnection' {
             Set-ADOPSServiceConnection @Splat
             Should -Invoke GetADOPSDefaultOrganization -ModuleName ADOPS -Times 1 -Exactly
         }
+
+        It 'Should call InvokeADOPSRestMethod with ManagedServiceIdentity scheme when -ManagedIdentity is used' {
+            $MsiSplat = @{
+                Project           = 'myproj'
+                TenantId          = 'AzureTennantId'
+                SubscriptionName  = 'AzureSubscriptionName'
+                SubscriptionId    = 'AzureSubscriptionId'
+                ServiceEndpointId = '8bce170f-ac4e-4164-a7d7-6cbc8f69f6af'
+                ManagedIdentity   = $true
+            }
+            Set-ADOPSServiceConnection @MsiSplat
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter {
+                ($Body | ConvertFrom-Json).authorization.scheme -eq 'ManagedServiceIdentity'
+            }
+        }
+
+        It 'Should call InvokeADOPSRestMethod with WorkloadIdentityFederation scheme when federation params are used' {
+            $WifSplat = @{
+                Project                            = 'myproj'
+                TenantId                           = 'AzureTennantId'
+                SubscriptionName                   = 'AzureSubscriptionName'
+                SubscriptionId                     = 'AzureSubscriptionId'
+                ServiceEndpointId                  = '8bce170f-ac4e-4164-a7d7-6cbc8f69f6af'
+                ServicePrincipalId                 = 'mySpId'
+                WorkloadIdentityFederationIssuer   = 'https://issuer.example.com'
+                WorkloadIdentityFederationSubject  = 'system:serviceaccount:default:mysa'
+            }
+            Set-ADOPSServiceConnection @WifSplat
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter {
+                ($Body | ConvertFrom-Json).authorization.scheme -eq 'WorkloadIdentityFederation'
+            }
+        }
+
+        It 'Should include the EndpointOperation in the URI when -EndpointOperation is specified' {
+            Set-ADOPSServiceConnection -EndpointOperation 'update' @Splat
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter {
+                $Uri -like '*operation=update*'
+            }
+        }
+
+        It 'Should NOT include EndpointOperation in URI when -EndpointOperation is not specified' {
+            Set-ADOPSServiceConnection @Splat
+            Should -Invoke InvokeADOPSRestMethod -ModuleName ADOPS -Times 1 -Exactly -ParameterFilter {
+                $Uri -notlike '*operation=*'
+            }
+        }
     }
 }


### PR DESCRIPTION
… EndpointOperation paths in Set-ADOPSServiceConnection

- Add test for ManagedServiceIdentity parameter set (lines 86-93)
- Add test for WorkloadIdentityFederation parameter set (lines 95-113)
- Add test for EndpointOperation URI branch when parameter is present
- Add test for EndpointOperation URI branch when parameter is absent
- Brings Set-ADOPSServiceConnection.ps1 coverage to 100%

# Contributing a Pull Request

If you haven't already, read the full [contribution guide](https://github.com/ADOPS/ADOPS/blob/main/CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [ ] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Verified build scripts work.
- [ ] Updated relevant and associated documentation.
