### PR TITLE
feat: add Get-ADOPSOrganizationCopilotCodeReview

### DIFF
--- a/Docs/Help/Get-ADOPSOrganizationCopilotCodeReview.md
+++ b/Docs/Help/Get-ADOPSOrganizationCopilotCodeReview.md
@@ -1,0 +1,70 @@
+---
+external help file: ADOPS-help.xml
+Module Name: ADOPS
+online version:
+schema: 2.0.0
+---
+
+# Get-ADOPSOrganizationCopilotCodeReview
+
+## SYNOPSIS
+Get the Azure DevOps organization wide GitHub Copilot code review settings
+
+## SYNTAX
+
+```
+Get-ADOPSOrganizationCopilotCodeReview [[-Organization] <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Get the Azure DevOps organization wide GitHub Copilot code review settings, found under Organization settings > Repositories.
+
+Returns an object with an isEnabled property, indicating whether repositories in the organization are allowed to use Copilot code review, and an agentPoolId property identifying the agent pool the reviewer runs on.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-ADOPSOrganizationCopilotCodeReview
+```
+
+Get the Copilot code review settings for the organization in the current context.
+
+### Example 2
+```powershell
+PS C:\> (Get-ADOPSOrganizationCopilotCodeReview -Organization 'myorg').isEnabled
+```
+
+Return only the enablement state for the named organization.
+
+## PARAMETERS
+
+### -Organization
+The organization to get the Copilot code review settings from.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS

--- a/Source/Public/Get-ADOPSOrganizationCopilotCodeReview.ps1
+++ b/Source/Public/Get-ADOPSOrganizationCopilotCodeReview.ps1
@@ -1,0 +1,23 @@
+function Get-ADOPSOrganizationCopilotCodeReview {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]$Organization
+    )
+
+    # If user didn't specify org, get it from saved context
+    if ([string]::IsNullOrEmpty($Organization)) {
+        $Organization = GetADOPSDefaultOrganization
+    }
+
+    $Body = '{
+        "contributionIds": [
+            "ms.vss-code-web.settings-options"
+        ]
+    }'
+
+    $Uri = "https://dev.azure.com/$Organization/_apis/Contribution/HierarchyQuery?api-version=7.1-preview"
+
+    (InvokeADOPSRestMethod -Uri $Uri -Method Post -Body $Body).dataProviders.'ms.vss-code-web.copilot-code-review-org-settings-data-provider'
+
+}

--- a/Tests/Get-ADOPSOrganizationCopilotCodeReview.Tests.ps1
+++ b/Tests/Get-ADOPSOrganizationCopilotCodeReview.Tests.ps1
@@ -1,0 +1,77 @@
+param(
+    $PSM1 = "$PSScriptRoot\..\Source\ADOPS.psm1"
+)
+
+BeforeAll {
+    Remove-Module ADOPS -Force -ErrorAction SilentlyContinue
+    Import-Module $PSM1 -Force
+}
+
+Describe 'Get-ADOPSOrganizationCopilotCodeReview' {
+    Context 'Parameters' {
+        $TestCases = @(
+            @{
+                Name      = 'Organization'
+                Mandatory = $false
+                Type      = 'string'
+            }
+        )
+
+        It 'Should have parameter <_.Name>' -TestCases $TestCases {
+            Get-Command Get-ADOPSOrganizationCopilotCodeReview | Should-HaveParameter $_.Name -Mandatory:$_.Mandatory -Type $_.Type
+        }
+    }
+
+    Context 'functionality' {
+        BeforeAll {
+            Mock -CommandName GetADOPSDefaultOrganization -ModuleName ADOPS -MockWith { 'DummyOrg' }
+
+            Mock -CommandName InvokeADOPSRestMethod -ModuleName ADOPS -MockWith {
+                return @'
+                {
+                    "dataProviders": {
+                        "ms.vss-web.component-data": {},
+                        "ms.vss-web.shared-data": null,
+                        "ms.vss-code-web.copilot-code-review-org-settings-data-provider": {
+                            "isEnabled": true,
+                            "agentPoolId": 9
+                        }
+                    }
+                }
+'@ | ConvertFrom-Json
+            }
+        }
+
+        It 'isEnabled Should be true' {
+            (Get-ADOPSOrganizationCopilotCodeReview).isEnabled | Should-Be $true
+        }
+
+        It 'agentPoolId Should be 9' {
+            (Get-ADOPSOrganizationCopilotCodeReview).agentPoolId | Should-Be 9
+        }
+
+        It 'Should get the organization from the saved context when not specified' {
+            Get-ADOPSOrganizationCopilotCodeReview
+            Should-Invoke GetADOPSDefaultOrganization -Times 1 -Exactly -ModuleName ADOPS
+        }
+
+        It 'Should not look up the default organization when one is specified' {
+            Get-ADOPSOrganizationCopilotCodeReview -Organization 'AnotherOrg'
+            Should-NotInvoke GetADOPSDefaultOrganization -ModuleName ADOPS
+        }
+
+        It 'Should post to the HierarchyQuery endpoint for the given organization' {
+            Get-ADOPSOrganizationCopilotCodeReview -Organization 'AnotherOrg'
+            Should-Invoke InvokeADOPSRestMethod -Times 1 -Exactly -ModuleName ADOPS -ParameterFilter {
+                $Method -eq 'Post' -and $Uri -eq 'https://dev.azure.com/AnotherOrg/_apis/Contribution/HierarchyQuery?api-version=7.1-preview'
+            }
+        }
+
+        It 'Should request the settings-options contribution' {
+            Get-ADOPSOrganizationCopilotCodeReview
+            Should-Invoke InvokeADOPSRestMethod -Times 1 -Exactly -ModuleName ADOPS -ParameterFilter {
+                $Body -match 'ms\.vss-code-web\.settings-options'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview/Summary

Fixes #265.

Adds `Get-ADOPSOrganizationCopilotCodeReview`, a cmdlet that reads the organization wide GitHub Copilot code
review setting found under **Organization settings > Repos > Repositories**.

The setting has no documented REST API and is only exposed through the contribution data provider that the
settings page itself calls, so the cmdlet posts to `HierarchyQuery` with the `ms.vss-code-web.settings-options`
contribution and returns the `ms.vss-code-web.copilot-code-review-org-settings-data-provider` object. This is
the same pattern `Get-ADOPSOrganizationPipelineSettings` already uses, and it needs nothing beyond the normal
ADOPS bearer token.

Returns `isEnabled`, plus `agentPoolId` when the organization is onboarded to the Copilot code review preview.

```powershell
Get-ADOPSOrganizationCopilotCodeReview
```

| Property | Example | Description |
| --- | --- | --- |
| `isEnabled` | `True` | Whether repositories in the organization are allowed to use Copilot code review |
| `agentPoolId` | `9` | Agent pool the reviewer runs on. Undocumented, and only present once the organization is onboarded |

Verified against two live organizations, one onboarded to the preview and one not.

## This PR fixes/adds/changes/removes

1. Adds `Source/Public/Get-ADOPSOrganizationCopilotCodeReview.ps1`, with an optional `-Organization` parameter
   that falls back to the saved context via `GetADOPSDefaultOrganization`, consistent with the other
   organization scoped cmdlets.
2. Adds `Tests/Get-ADOPSOrganizationCopilotCodeReview.Tests.ps1`, 7 tests written against the Pester 6
   assertion syntax introduced in #264.
3. Adds `Docs/Help/Get-ADOPSOrganizationCopilotCodeReview.md` for platyPS external help.

No existing files are modified. `Source/ADOPS.psd1` is deliberately untouched, since `FunctionsToExport` is
`'*'` in source and the explicit list is generated by the `Compile_Module` build task.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/ADOPS/ADOPS/pulls)
- [x] Associated it with relevant [issues](https://github.com/ADOPS/ADOPS/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/ADOPS/ADOPS/tree/main)
- [x] Performed testing and provided evidence.
- [x] Verified build scripts work.
- [x] Updated relevant and associated documentation.

### Evidence

Branch is based on `65be220` (Pester V6 test conversion), 0 commits behind `main`.

Full source suite:

```
.\Tests\TestRunner.ps1 -ModuleLoadPath .\Source\ADOPS.psm1
Tests Passed: 1769, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
```

Full build, default task chain (Clean, Unit_Tests, RunScriptAnalyzer, Build_Documentation, Compile_Module,
Unit_Tests_Compiled):

```
Invoke-Build -File .\ADOPS.Build.ps1
Tests Passed: 1025, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
Covered 91,78% / 75%. 1 666 analyzed Commands in 1 File.
Build succeeded. 7 tasks, 0 errors, 0 warnings
```

The 7 tests for the new cmdlet, plus the generic `Module.tests.ps1` requirements it has to satisfy:

```
[+] Should have parameter Organization
[+] isEnabled Should be true
[+] agentPoolId Should be 9
[+] Should get the organization from the saved context when not specified
[+] Should not look up the default organization when one is specified
[+] Should post to the HierarchyQuery endpoint for the given organization
[+] Should request the settings-options contribution
[+] Public function 'Get-ADOPSOrganizationCopilotCodeReview' should have parameter Organization.
[+] Public function 'Get-ADOPSOrganizationCopilotCodeReview' should have a CmdLet file in correct place.
[+] Public function 'Get-ADOPSOrganizationCopilotCodeReview' should have a test file.
[+] Public function 'Get-ADOPSOrganizationCopilotCodeReview' should have a Docs/Help file.
[+] Public function 'Get-ADOPSOrganizationCopilotCodeReview' should not have empty descriptions in help file
[+] Docs/Help file for 'Get-ADOPSOrganizationCopilotCodeReview' contains parameter 'Organization'.
[+] Parameter 'Organization'in function 'Get-ADOPSOrganizationCopilotCodeReview' is PascalCase (starts with capital letter).
```

### One note for reviewers

The data provider is returned whether or not the organization is onboarded to the limited public preview, and
reports `isEnabled: false` in both cases:

| Organization state | Provider value |
| --- | --- |
| Not onboarded to the preview | `{ isEnabled: false, lastBulkAction: "" }` |
| Onboarded, switched off | `{ isEnabled: false, ... }` |
| Onboarded, switched on | `{ isEnabled: true, agentPoolId: 9 }` |

This cmdlet returns the provider as-is and does not try to interpret that. If it would be useful to
distinguish the first row from the second, the `SourceControl.GitPullRequests.CopilotReview` flag under
`dataProviderSharedData._featureFlags` is `False` only in the first case. Happy to add that if you want it
surfaced, though it felt like caller policy rather than something the cmdlet should decide.
